### PR TITLE
Remote as variables

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,9 @@
       <_Parameter1>$(AssemblyName).Test</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Specs</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/RepoM.Api.Common/IO/Methods/FindFilesMethod.cs
+++ b/src/RepoM.Api.Common/IO/Methods/FindFilesMethod.cs
@@ -48,8 +48,7 @@ public class FindFilesMethod : IMethod
             return CombinedTypeContainer.NullInstance;
         }
     }
-
-
+    
     private static IEnumerable<string> GetFileEnumerator(string path, string searchPattern)
     {
         // prefer EnumerateFileSystemInfos() over EnumerateFiles() to include packaged folders like

--- a/src/RepoM.Api.Common/IO/ModuleBasedRepositoryActionProvider/ActionMappers/ActionAssociateFileV1Mapper.cs
+++ b/src/RepoM.Api.Common/IO/ModuleBasedRepositoryActionProvider/ActionMappers/ActionAssociateFileV1Mapper.cs
@@ -92,7 +92,6 @@ public class ActionAssociateFileV1Mapper : IActionToRepositoryActionMapper
             {
                 DeferredSubActionsEnumerator = () =>
                     GetFiles(repository, filePattern)
-                        .Select(solutionFile => NameHelper.ReplaceVariables(solutionFile, repository))
                         .Select(solutionFile => CreateProcessRunnerAction(Path.GetFileName(solutionFile), solutionFile))
                         .ToArray(),
             };

--- a/src/RepoM.Api.Common/IO/ModuleBasedRepositoryActionProvider/ActionMappers/ActionBrowseRepositoryV1Mapper.cs
+++ b/src/RepoM.Api.Common/IO/ModuleBasedRepositoryActionProvider/ActionMappers/ActionBrowseRepositoryV1Mapper.cs
@@ -58,7 +58,7 @@ public class ActionBrowseRepositoryV1Mapper : IActionToRepositoryActionMapper
 
     private RepositoryAction? CreateBrowseRemoteAction(Repository repository, RepositoryActionBrowseRepositoryV1 action)
     {
-        if (repository.RemoteUrls.Length == 0)
+        if (repository.Remotes.Count == 0)
         {
             return null;
         }
@@ -71,16 +71,16 @@ public class ActionBrowseRepositoryV1Mapper : IActionToRepositoryActionMapper
 
         var actionName = _translationService.Translate("Browse remote");
 
-        if (repository.RemoteUrls.Length == 1 || forceSingle)
+        if (repository.Remotes.Count == 1 || forceSingle)
         {
-            return CreateProcessRunnerAction(actionName, repository.RemoteUrls[0]);
+            return CreateProcessRunnerAction(actionName, repository.Remotes[0].Url);
         }
 
         return new RepositoryAction(actionName)
             {
-                DeferredSubActionsEnumerator = () => repository.RemoteUrls
+                DeferredSubActionsEnumerator = () => repository.Remotes
                                                                .Take(50)
-                                                               .Select(url => CreateProcessRunnerAction(url, url))
+                                                               .Select(remote => CreateProcessRunnerAction(remote.Name, remote.Url))
                                                                .ToArray(),
             };
     }

--- a/src/RepoM.Api.Common/IO/NameHelper.cs
+++ b/src/RepoM.Api.Common/IO/NameHelper.cs
@@ -1,6 +1,5 @@
 namespace RepoM.Api.Common.IO;
 
-using System;
 using RepoM.Api.Common.Common;
 using RepoM.Api.Common.IO.ExpressionEvaluator;
 using RepoM.Api.Git;
@@ -15,25 +14,6 @@ public static class NameHelper
                 translationService.Translate(input ?? string.Empty),
                 translationService),
             repository);
-    }
-
-    public static string ReplaceVariables(string? value, Repository repository)
-    {
-        if (value is null)
-        {
-            return string.Empty;
-        }
-
-        return Environment.ExpandEnvironmentVariables(
-            value
-                .Replace("{Repository.Name}", repository.Name)
-                .Replace("{Repository.Path}", repository.Path)
-                .Replace("{Repository.SafePath}", repository.SafePath)
-                .Replace("{Repository.Location}", repository.Location)
-                .Replace("{Repository.CurrentBranch}", repository.CurrentBranch)
-                .Replace("{Repository.Branches}", string.Join("|", repository.Branches ?? Array.Empty<string>()))
-                .Replace("{Repository.LocalBranches}", string.Join("|", repository.LocalBranches ?? Array.Empty<string>()))
-                .Replace("{Repository.RemoteUrls}", string.Join("|", repository.RemoteUrls ?? Array.Empty<string>())));
     }
 
     private static string ReplaceTranslatables(string? value, ITranslationService translationService)

--- a/src/RepoM.Api.Common/IO/RepositoryVariableProvider.cs
+++ b/src/RepoM.Api.Common/IO/RepositoryVariableProvider.cs
@@ -70,9 +70,47 @@ public class RepositoryVariableProvider : IVariableProvider<RepositoryContext>
             return string.Join("|", repository.LocalBranches);
         }
 
+        // legacy
         if ("RemoteUrls".Equals(keySuffix, StringComparison.CurrentCultureIgnoreCase))
         {
-            return string.Join("|", repository.RemoteUrls);
+            return string.Join("|", repository.Remotes.Select(x => x.Url));
+        }
+
+        if (keySuffix.StartsWith("Remote.", StringComparison.CurrentCultureIgnoreCase))
+        {
+            var subKey = keySuffix.Substring(2);
+
+            startIndex = "Remote.".Length;
+            keySuffix = keySuffix.Substring(startIndex, keySuffix.Length - startIndex);
+
+            var splits = keySuffix.Split('.');
+            if (splits.Length != 2)
+            {
+                return string.Empty;
+            }
+
+            Remote? remote = repository.Remotes.FirstOrDefault(x => x.Key.Equals(splits[0], StringComparison.CurrentCultureIgnoreCase));
+            if (remote == null)
+            {
+                return string.Empty;
+            }
+
+            if ("url".Equals(splits[1], StringComparison.CurrentCultureIgnoreCase))
+            {
+                return remote.Url;
+            }
+
+            if ("key".Equals(splits[1], StringComparison.CurrentCultureIgnoreCase))
+            {
+                return remote.Key;
+            }
+
+            if ("name".Equals(splits[1], StringComparison.CurrentCultureIgnoreCase))
+            {
+                return remote.Name;
+            }
+
+            return string.Empty;
         }
 
         throw new NotImplementedException();

--- a/src/RepoM.Api/Git/Remote.cs
+++ b/src/RepoM.Api/Git/Remote.cs
@@ -1,0 +1,69 @@
+namespace RepoM.Api.Git;
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Xml.Linq;
+
+[DebuggerDisplay("{Key}/{Name}")]
+public class Remote
+{
+    public Remote(string key, string url)
+    {
+        Key = key;
+        Url = url;
+        Name = CalculateName(url);
+    }
+
+    public string Key { get; }
+
+    public string Name { get; set; }
+
+    public string Url { get; }
+
+    private static string CalculateName(string url)
+    {
+        string name;
+
+        try
+        {
+            var fi = new FileInfo(url);
+            name = fi.Name.Trim();
+            name = StripDotGit(name);
+        }
+        catch (Exception)
+        {
+            name = string.Empty;
+        }
+
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+        
+        try
+        {
+            var parts = url.Split('/', '\\');
+            name = parts[parts.Length - 1];
+            name = StripDotGit(name);
+        }
+        catch (Exception)
+        {
+            name = string.Empty;
+        }
+
+        return name;
+    }
+
+    private static string StripDotGit(string input)
+    {
+        var output = input;
+
+        if (output.EndsWith(".git", StringComparison.CurrentCultureIgnoreCase))
+        {
+            output = output.Substring(0, output.Length - ".git".Length);
+        }
+
+        return output;
+    }
+}

--- a/src/RepoM.Api/Git/Repository.cs
+++ b/src/RepoM.Api/Git/Repository.cs
@@ -1,6 +1,7 @@
 namespace RepoM.Api.Git;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 [DebuggerDisplay("{Name} @{Path}")]
@@ -107,7 +108,7 @@ public class Repository
 
     public int? StashCount { get; set; }
 
-    public string[] RemoteUrls { get; set; } = Array.Empty<string>();
+    public List<Remote> Remotes { get; } = new List<Remote>(1);
 
     public string SafePath
     {

--- a/src/RepoM.Api/Git/RepositoryView.cs
+++ b/src/RepoM.Api/Git/RepositoryView.cs
@@ -83,8 +83,6 @@ public class RepositoryView : IRepositoryView, INotifyPropertyChanged
 
     public string LocalIgnored => Repository.LocalIgnored?.ToString() ?? string.Empty;
 
-    public string[] RemoteUrls => Repository.RemoteUrls ?? Array.Empty<string>();
-
     public string StashCount => Repository.StashCount?.ToString() ?? string.Empty;
 
     public bool WasFound => Repository.WasFound;

--- a/src/RepoM.Plugin.SonarCloud/ActionSonarCloudSetFavoriteV1Deserializer.cs
+++ b/src/RepoM.Plugin.SonarCloud/ActionSonarCloudSetFavoriteV1Deserializer.cs
@@ -11,7 +11,7 @@ using RepoM.Api.Git;
 using RepositoryAction = RepoM.Api.Common.IO.ModuleBasedRepositoryActionProvider.Data.RepositoryAction;
 
 [UsedImplicitly]
-internal class ActionSonarCloudV1Deserializer : IActionDeserializer
+internal class ActionSonarCloudSetFavoriteV1Deserializer : IActionDeserializer
 {
     public bool CanDeserialize(string type)
     {

--- a/src/RepoM.Plugin.SonarCloud/SonarCloudPackage.cs
+++ b/src/RepoM.Plugin.SonarCloud/SonarCloudPackage.cs
@@ -12,7 +12,7 @@ public class SonarCloudPackage : IPackage
 {
     public void RegisterServices(Container container)
     {
-        container.Collection.Append<IActionDeserializer, ActionSonarCloudV1Deserializer>(Lifestyle.Singleton);
+        container.Collection.Append<IActionDeserializer, ActionSonarCloudSetFavoriteV1Deserializer>(Lifestyle.Singleton);
         container.Collection.Append<IActionToRepositoryActionMapper, ActionSonarCloudV1Mapper>(Lifestyle.Singleton);
         container.Collection.Append<IMethod, SonarCloudIsFavoriteMethod>(Lifestyle.Singleton);
 

--- a/tests/RepoM.Api.Common.Tests/IO/ModuleBasedRepositoryActionProvider/EasyTestFileSettingsExtensions.cs
+++ b/tests/RepoM.Api.Common.Tests/IO/ModuleBasedRepositoryActionProvider/EasyTestFileSettingsExtensions.cs
@@ -2,7 +2,7 @@ namespace RepoM.Api.Common.Tests.IO.ModuleBasedRepositoryActionProvider;
 
 using EasyTestFile;
 
-internal static class EasyTestFileSettingsExtensions
+public static class EasyTestFileSettingsExtensions
 {
     public static EasyTestFileSettings SetExtension(this EasyTestFileSettings @this, SerializationType type)
     {

--- a/tests/RepoM.Plugin.SonarCloud.Tests/RepoM.Plugin.SonarCloud.Tests.csproj
+++ b/tests/RepoM.Plugin.SonarCloud.Tests/RepoM.Plugin.SonarCloud.Tests.csproj
@@ -10,16 +10,34 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="EasyTestFile.XUnit" Version="2.0.3" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.0.18" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.0.18" />
     <PackageReference Include="Verify.Xunit" Version="17.1.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.EnumMemberData" Version="1.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
     <PackageReference Include="SonarQube.Net" Version="1.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RepoM.Plugin.SonarCloud\RepoM.Plugin.SonarCloud.csproj" />
+    <ProjectReference Include="..\RepoM.Api.Common.Tests\RepoM.Api.Common.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestFiles\" />
   </ItemGroup>
 
 </Project>

--- a/tests/RepoM.Plugin.SonarCloud.Tests/SonarCloudSetFavoriteV1Test.cs
+++ b/tests/RepoM.Plugin.SonarCloud.Tests/SonarCloudSetFavoriteV1Test.cs
@@ -1,0 +1,83 @@
+namespace RepoM.Plugin.SonarCloud.Tests;
+
+using System;
+using System.Threading.Tasks;
+using EasyTestFile;
+using EasyTestFileXunit;
+using FluentAssertions;
+using RepoM.Api.Common.IO.ModuleBasedRepositoryActionProvider;
+using RepoM.Api.Common.IO.ModuleBasedRepositoryActionProvider.ActionDeserializers;
+using RepoM.Api.Common.IO.ModuleBasedRepositoryActionProvider.Data;
+using RepoM.Api.Common.IO.ModuleBasedRepositoryActionProvider.Deserialization;
+using RepoM.Api.Common.Tests.IO.ModuleBasedRepositoryActionProvider;
+using RepoM.Plugin.SonarCloud;
+using VerifyTests;
+using VerifyXunit;
+using Xunit;
+using XunitEnumMemberData;
+
+[UsesEasyTestFile]
+[UsesVerify]
+public class SonarCloudSetFavoriteV1Test
+{
+    private readonly JsonDynamicRepositoryActionDeserializer _sutJson;
+    private readonly EasyTestFileSettings _testFileSettings;
+    private readonly VerifySettings _verifySettings;
+    private readonly YamlDynamicRepositoryActionDeserializer _sutYaml;
+
+    public SonarCloudSetFavoriteV1Test()
+    {
+        _sutJson = CreateWithDeserializer(new ActionSonarCloudSetFavoriteV1Deserializer());
+        _sutYaml = new YamlDynamicRepositoryActionDeserializer(_sutJson);
+
+        _testFileSettings = new EasyTestFileSettings();
+        _testFileSettings.UseDirectory("TestFiles");
+        _testFileSettings.UseExtension("json");
+
+        _verifySettings = new VerifySettings();
+        _verifySettings.UseDirectory("Verified");
+    }
+
+    [Theory]
+    [EnumMemberData(typeof(SerializationType))]
+    public async Task Deserialize(SerializationType type)
+    {
+        // arrange
+        var content = await EasyTestFile.LoadAsText(_testFileSettings.SetExtension(type));
+
+        // act
+        RepositoryActionConfiguration result = SutDeserialize(content, type);
+
+        // assert
+        await Verifier.Verify(result, _verifySettings).IgnoreParametersForVerified(type);
+    }
+
+    [Fact]
+    public async Task Deserialize_ShouldBeOfExpectedType()
+    {
+        // arrange
+        _testFileSettings.UseMethodName(nameof(Deserialize));
+        var content = await EasyTestFile.LoadAsText(_testFileSettings);
+
+        // act
+        RepositoryActionConfiguration result = SutDeserialize(content, SerializationType.Json);
+
+        // assert
+        _ = result.ActionsCollection.Actions.Should().AllBeOfType<RepositoryActionSonarCloudSetFavoriteV1>();
+    }
+
+    private RepositoryActionConfiguration SutDeserialize(string rawContent, SerializationType type)
+    {
+        return type switch
+            {
+                SerializationType.Json => _sutJson.Deserialize(rawContent),
+                SerializationType.Yaml => _sutYaml.Deserialize(rawContent),
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
+    }
+
+    private static JsonDynamicRepositoryActionDeserializer CreateWithDeserializer(IActionDeserializer actionDeserializer)
+    {
+        return new JsonDynamicRepositoryActionDeserializer(new ActionDeserializerComposition(new IActionDeserializer[] { actionDeserializer, }));
+    }
+}

--- a/tests/RepoM.Plugin.SonarCloud.Tests/TestFiles/SonarCloudSetFavoriteV1Test.Deserialize.testfile.json
+++ b/tests/RepoM.Plugin.SonarCloud.Tests/TestFiles/SonarCloudSetFavoriteV1Test.Deserialize.testfile.json
@@ -1,0 +1,12 @@
+{
+  "repository-actions": {
+    "actions": [
+      {
+        "type": "sonarcloud-set-favorite@1",
+        "name": "Star project",
+        "project": "project-a",
+        "active": true
+      }
+    ]
+  }
+}

--- a/tests/RepoM.Plugin.SonarCloud.Tests/TestFiles/SonarCloudSetFavoriteV1Test.Deserialize.testfile.yaml
+++ b/tests/RepoM.Plugin.SonarCloud.Tests/TestFiles/SonarCloudSetFavoriteV1Test.Deserialize.testfile.yaml
@@ -1,0 +1,6 @@
+repository-actions:
+  actions:
+  - type: sonarcloud-set-favorite@1
+    name: Star project
+    active: true
+    project: project-a

--- a/tests/RepoM.Plugin.SonarCloud.Tests/TestFramework/VerifierInitializer.cs
+++ b/tests/RepoM.Plugin.SonarCloud.Tests/TestFramework/VerifierInitializer.cs
@@ -1,0 +1,15 @@
+namespace RepoM.Plugin.SonarCloud.Tests.TestFramework;
+
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+using VerifyTests;
+
+public static class VerifierInitializer
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        VerifierSettings.DisableRequireUniquePrefix();
+        VerifierSettings.AddExtraSettings(serializerSettings => serializerSettings.TypeNameHandling = TypeNameHandling.Auto);
+    }
+}

--- a/tests/RepoM.Plugin.SonarCloud.Tests/Verified/SonarCloudSetFavoriteV1Test.Deserialize.verified.txt
+++ b/tests/RepoM.Plugin.SonarCloud.Tests/Verified/SonarCloudSetFavoriteV1Test.Deserialize.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  TagsCollection: {},
+  ActionsCollection: {
+    Actions: [
+      {
+        $type: RepositoryActionSonarCloudSetFavoriteV1,
+        Project: project-a,
+        Type: sonarcloud-set-favorite@1,
+        Name: Star project,
+        Active: true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Support for new variables:
```yaml
{Repository.remote.<remote key>.url}
{Repository.remote.<remote key>.name}
{Repository.remote.<remote key>.key}
```
ie
- `{Repository.remote.origin.url}` might evaluate into `https://github.com/coenm/RepoM.git`
- Then, `{Repository.remote.origin.name}` results in `RepoM`.
The name of the remote can be obtained using `{Repository.remote.origin.key}` which in this example results in `origin`
