### PR TITLE
Allow fork based pull requests build in Azure Devops

### DIFF
--- a/.azuredevops/Pipelines/Templates/prepare-code-analysis.yaml
+++ b/.azuredevops/Pipelines/Templates/prepare-code-analysis.yaml
@@ -10,3 +10,5 @@ steps:
     extraProperties: |
       sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)/**/*.trx
       sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/*.opencover.xml
+  condition: or( ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'false') )
+  

--- a/.azuredevops/Pipelines/Templates/publish-code-analysis.yaml
+++ b/.azuredevops/Pipelines/Templates/publish-code-analysis.yaml
@@ -2,9 +2,11 @@ steps:
 
 - task: SonarCloudAnalyze@2
   displayName: ⚙️ Run Code Analysis
+  condition: or( ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'false') )
 
 - task: SonarCloudPublish@2
   displayName: 📢 Publish Quality Gate Result
+  condition: or( ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'false') )
 
 - pwsh: |
     dotnet tool install --tool-path . dotnet-reportgenerator-globaltool


### PR DESCRIPTION
Exclude the sonar cloud tasks when executing the Azure pipeline for pull requests when the pull request is originated from a fork.

Fixes #116