### PR TITLE
Performance improvement of file searching

### DIFF
--- a/src/RepoM.App/MainWindow.xaml.cs
+++ b/src/RepoM.App/MainWindow.xaml.cs
@@ -282,15 +282,7 @@ public partial class MainWindow
                     items.Add(new Separator());
                 }
             }
-            else if (action is DeferredSubActionsUserInterfaceRepositoryAction deferredAction)
-            {
-                Control? controlItem = CreateMenuItemNewStyleAsync(action, vm);
-                if (controlItem != null)
-                {
-                    items.Add(controlItem);
-                }
-            }
-            else if (action is UserInterfaceRepositoryAction uiAction)
+            else if (action is DeferredSubActionsUserInterfaceRepositoryAction or UserInterfaceRepositoryAction)
             {
                 Control? controlItem = CreateMenuItemNewStyleAsync(action, vm);
                 if (controlItem != null)

--- a/tests/RepoM.ActionMenu.Core.Tests/ActionMenu/Context/FileFunctionsTests.cs
+++ b/tests/RepoM.ActionMenu.Core.Tests/ActionMenu/Context/FileFunctionsTests.cs
@@ -35,21 +35,18 @@ public class FileFunctionsTests
     public void FindFiles_ShouldReturnEmpty_WhenNoFilesFound()
     {
         // arrange
-        var path = "my-path";
-        var search = "my-search";
-        var files = Array.Empty<IFileSystemInfo>();
-        IDirectoryInfo di = A.Fake<IDirectoryInfo>();
-        A.CallTo(() => _fileSystem.DirectoryInfo.New(path)).Returns(di);
-        A.CallTo(() => di.EnumerateFileSystemInfos(search, SearchOption.AllDirectories))
-         .Returns(files);
+        const string PATH = "my-path";
+        const string SEARCH = "my-search";
+        A.CallTo(() => _fileSystem.Directory.EnumerateFileSystemEntries(PATH, SEARCH, A<EnumerationOptions>._))
+         .Returns(Array.Empty<string>());
 
         // act
-        IEnumerable result = Sut.FindFilesInner(_context, _span, path, search);
+        IEnumerable result = Sut.FindFilesInner(_context, _span, PATH, SEARCH);
 
         // assert
         result.Should().BeEquivalentTo(Array.Empty<string>());
-        A.CallTo(() => _fileSystem.DirectoryInfo.New(path)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => di.EnumerateFileSystemInfos(search, SearchOption.AllDirectories)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _fileSystem.Directory.EnumerateFileSystemEntries(PATH, SEARCH, A<EnumerationOptions>._))
+         .MustHaveHappenedOnceExactly();
     }
     
     [Theory]


### PR DESCRIPTION
Performance improvement.

Improve file search in scriban file functions by specifying EnumerationOptions to be more strict. Also select only filenames instead of constructing `FileSystemInfo` and only use the filename.