### PR TITLE
Material3 Themes UI Upgrade + Update MaterialDesignThemes.MahApps

### DIFF
--- a/src/RepoM.App/ActionMenuCore/RepositoryTagsFactoryV2.cs
+++ b/src/RepoM.App/ActionMenuCore/RepositoryTagsFactoryV2.cs
@@ -21,14 +21,11 @@ public class RepositoryTagsFactoryV2 : IRepositoryTagsFactory
         IAppDataPathProvider appDataPathProvider)
     {
         _ = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-        _newStyleActionMenuFactory = newStyleActionMenuFactory ?? throw new ArgumentNullException(nameof(newStyleActionMenuFactory));
+        this._newStyleActionMenuFactory = newStyleActionMenuFactory ?? throw new ArgumentNullException(nameof(newStyleActionMenuFactory));
         _ = appDataPathProvider ?? throw new ArgumentNullException(nameof(appDataPathProvider));
 
-        _filename = fileSystem.Path.Combine(appDataPathProvider.AppDataPath, "TagsV2.yaml");
+        this._filename = fileSystem.Path.Combine(appDataPathProvider.AppDataPath, "TagsV2.yaml");
     }
 
-    public Task<IEnumerable<string>> GetTagsAsync(Repository repository)
-    {
-        return _newStyleActionMenuFactory.GetTagsAsync(repository, _filename);
-    }
+    public Task<IEnumerable<string>> GetTagsAsync(Repository repository) => this._newStyleActionMenuFactory.GetTagsAsync(repository, this._filename);
 }

--- a/src/RepoM.App/App.xaml
+++ b/src/RepoM.App/App.xaml
@@ -10,26 +10,26 @@
     >
     <Application.Resources>
 
-		<!--
+        <!--
             Note that this application does not have a StartupUri declared, so no Window is automatically loaded.
             Also, the ShutdownMode was set to explicit, so we have to close the application programmatically
         -->
 
-		<ResourceDictionary>
+        <ResourceDictionary>
 
-			<!--
+            <!--
                 Integrate MahApps to Material Design Toolkit
                 https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/wiki/MahApps.Metro-integration
             -->
 
-			<ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.MergedDictionaries>
 
-				<ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml" />
 
 
-				<!-- MahApps -->
+                <!--  MahApps  -->
 
                 <!--  Material Design  -->
                 <materialDesign:BundledTheme
@@ -42,10 +42,10 @@
                 <!--  Material Design: MahApps Compatibility  -->
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
 
-				<!-- merge NotifyIcon and related stuff into the application -->
-				<ResourceDictionary Source="NotifyIconResources.xaml" />
+                <!--  merge NotifyIcon and related stuff into the application  -->
+                <ResourceDictionary Source="NotifyIconResources.xaml" />
 
-			</ResourceDictionary.MergedDictionaries>
+            </ResourceDictionary.MergedDictionaries>
 
 
             <!--  Dark  -->
@@ -58,19 +58,19 @@
 
             <Style BasedOn="{StaticResource {x:Type TextBox}}" TargetType="{x:Type controls:ZTextBox}" />
 
-			<Style TargetType="{x:Type controls:AcrylicContextMenu}" BasedOn="{StaticResource {x:Type ContextMenu}}" >
-				<Setter Property="Background" Value="#50000000" />
-				<Setter Property="FontSize" Value="13.5" />
+            <Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type controls:AcrylicContextMenu}">
+                <Setter Property="Background" Value="#50000000" />
+                <Setter Property="FontSize" Value="13.5" />
 
-			</Style>
+            </Style>
 
 
-			<Style TargetType="{x:Type controls:AcrylicMenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}" >
-				<Setter Property="Background" Value="Transparent"/>
-			</Style>
+            <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type controls:AcrylicMenuItem}">
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
 
-		</ResourceDictionary>
+        </ResourceDictionary>
 
-	</Application.Resources>
+    </Application.Resources>
 
 </Application>

--- a/src/RepoM.App/App.xaml
+++ b/src/RepoM.App/App.xaml
@@ -1,8 +1,13 @@
-﻿<Application x:Class="RepoM.App.App"
-			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:controls="clr-namespace:RepoM.App.Controls"
-			 ShutdownMode="OnExplicitShutdown">
+<Application
+    x:Class="RepoM.App.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:RepoM.App.Controls"
+    xmlns:local="clr-namespace:RepoM.App"
+    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    ShutdownMode="OnExplicitShutdown"
+    >
     <Application.Resources>
 
 		<!--
@@ -26,70 +31,32 @@
 
 				<!-- MahApps -->
 
-				<!-- Material Design -->
-				<!--<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />-->
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.LightBlue.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.LightBlue.xaml" />
+                <!--  Material Design  -->
+                <materialDesign:BundledTheme
+                    BaseTheme="Inherit"
+                    PrimaryColor="LightBlue"
+                    SecondaryColor="LightBlue"
+                    />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
 
-				<!-- Material Design: MahApps Compatibility -->
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
-				<!-- CRASHES?! <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml" />-->
+                <!--  Material Design: MahApps Compatibility  -->
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
 
 				<!-- merge NotifyIcon and related stuff into the application -->
 				<ResourceDictionary Source="NotifyIconResources.xaml" />
 
 			</ResourceDictionary.MergedDictionaries>
 
-			<!-- MahApps Brushes -->
 
-			<!-- Light/Dark MaterialDesign themes to MahApps -->
-			<!--   WindowTitleColorBrush		= MaterialDesignPaper -->
-			<!--   IdealForegroundColorBrush	= MaterialDesignBody -->
+            <!--  Dark  -->
+            <SolidColorBrush x:Key="WindowTitleColorBrush" Color="#FF303030" />
+            <SolidColorBrush x:Key="IdealForegroundColorBrush" Color="#DDFFFFFF" />
 
-			<!-- Light -->
-			<!--
-			<SolidColorBrush x:Key="WindowTitleColorBrush" Color="#FFfafafa"/>
-			<SolidColorBrush x:Key="IdealForegroundColorBrush" Color="#DD000000"/>
-			-->
+            <!--  Repo Name colour  -->
+            <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource Theme.PrimaryAccentColor}" />
 
-			<!-- Dark -->
-			<SolidColorBrush x:Key="WindowTitleColorBrush"
-							 Color="#FF303030" />
-			<SolidColorBrush x:Key="IdealForegroundColorBrush"
-							 Color="#DDFFFFFF" />
 
-			<SolidColorBrush x:Key="HighlightBrush"
-							 Color="{DynamicResource Primary700}" />
-			<SolidColorBrush x:Key="AccentColorBrush"
-							 Color="{DynamicResource Primary500}" />
-			<!-- main accent -->
-			<SolidColorBrush x:Key="AccentColorBrush2"
-							 Color="{DynamicResource Primary400}" />
-			<SolidColorBrush x:Key="AccentColorBrush3"
-							 Color="{DynamicResource Primary300}" />
-			<SolidColorBrush x:Key="AccentColorBrush4"
-							 Color="{DynamicResource Primary200}" />
-			<SolidColorBrush x:Key="AccentSelectedColorBrush"
-							 Color="{DynamicResource Primary500Foreground}" />
-			<LinearGradientBrush x:Key="ProgressBrush"
-								 EndPoint="0.001,0.5"
-								 StartPoint="1.002,0.5">
-				<GradientStop Color="{DynamicResource Primary700}"
-							  Offset="0" />
-				<GradientStop Color="{DynamicResource Primary300}"
-							  Offset="1" />
-			</LinearGradientBrush>
-			<SolidColorBrush x:Key="CheckmarkFill"
-							 Color="{DynamicResource Primary500}" />
-			<SolidColorBrush x:Key="RightArrowFill"
-							 Color="{DynamicResource Primary500}" />
-			<SolidColorBrush x:Key="IdealForegroundDisabledBrush"
-							 Color="{DynamicResource Primary500}"
-							 Opacity="0.4" />
-
-			<Style TargetType="{x:Type controls:ZTextBox}" BasedOn="{StaticResource {x:Type TextBox}}" />
+            <Style BasedOn="{StaticResource {x:Type TextBox}}" TargetType="{x:Type controls:ZTextBox}" />
 
 			<Style TargetType="{x:Type controls:AcrylicContextMenu}" BasedOn="{StaticResource {x:Type ContextMenu}}" >
 				<Setter Property="Background" Value="#50000000" />

--- a/src/RepoM.App/App.xaml
+++ b/src/RepoM.App/App.xaml
@@ -1,12 +1,12 @@
 <Application
-    x:Class="RepoM.App.App"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:RepoM.App.Controls"
-    xmlns:local="clr-namespace:RepoM.App"
-    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-    ShutdownMode="OnExplicitShutdown"
+    x:Class              = "RepoM.App.App"
+    xmlns                = "http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x              = "http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls       = "clr-namespace:RepoM.App.Controls"
+    xmlns:local          = "clr-namespace:RepoM.App"
+    xmlns:mah            = "http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:materialDesign = "http://materialdesigninxaml.net/winfx/xaml/themes"
+    ShutdownMode         = "OnExplicitShutdown"
     >
     <Application.Resources>
 
@@ -19,54 +19,53 @@
 
             <!--
                 Integrate MahApps to Material Design Toolkit
-                https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/wiki/MahApps.Metro-integration
+                https:   //github.com/ButchersBoy/MaterialDesignInXamlToolkit/wiki/MahApps.Metro-integration
             -->
 
             <ResourceDictionary.MergedDictionaries>
 
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml" />
+                <ResourceDictionary Source = "pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <ResourceDictionary Source = "pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source = "pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml" />
 
 
                 <!--  MahApps  -->
 
                 <!--  Material Design  -->
                 <materialDesign:BundledTheme
-                    BaseTheme="Inherit"
-                    PrimaryColor="LightBlue"
-                    SecondaryColor="LightBlue"
+                    BaseTheme      = "Inherit"
+                    PrimaryColor   = "LightBlue"
+                    SecondaryColor = "LightBlue"
                     />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
+                <ResourceDictionary Source = "pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
 
-                <!--  Material Design: MahApps Compatibility  -->
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
+                <!-- Material Design: MahApps Compatibility  -->
+                <ResourceDictionary Source = "pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
 
                 <!--  merge NotifyIcon and related stuff into the application  -->
-                <ResourceDictionary Source="NotifyIconResources.xaml" />
+                <ResourceDictionary Source = "NotifyIconResources.xaml" />
 
             </ResourceDictionary.MergedDictionaries>
 
 
             <!--  Dark  -->
-            <SolidColorBrush x:Key="WindowTitleColorBrush" Color="#FF303030" />
-            <SolidColorBrush x:Key="IdealForegroundColorBrush" Color="#DDFFFFFF" />
+            <SolidColorBrush x:Key = "WindowTitleColorBrush" Color     = "#FF303030" />
+            <SolidColorBrush x:Key = "IdealForegroundColorBrush" Color = "#DDFFFFFF" />
 
             <!--  Repo Name colour  -->
-            <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource Theme.PrimaryAccentColor}" />
+            <SolidColorBrush x:Key = "AccentColorBrush" Color = "{DynamicResource Theme.PrimaryAccentColor}" />
 
 
-            <Style BasedOn="{StaticResource {x:Type TextBox}}" TargetType="{x:Type controls:ZTextBox}" />
+            <Style BasedOn = "{StaticResource {x:Type TextBox}}" TargetType = "{x:Type controls:ZTextBox}" />
 
-            <Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type controls:AcrylicContextMenu}">
-                <Setter Property="Background" Value="#50000000" />
-                <Setter Property="FontSize" Value="13.5" />
-
+            <Style BasedOn  = "{StaticResource {x:Type ContextMenu}}" TargetType = "{x:Type controls:AcrylicContextMenu}">
+                <Setter Property = "Background" Value                                 = "#50000000" />
+                <Setter Property = "FontSize" Value                                   = "13.5" />
             </Style>
 
 
-            <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type controls:AcrylicMenuItem}">
-                <Setter Property="Background" Value="Transparent" />
+            <Style  BasedOn  = "{StaticResource {x:Type MenuItem}}" TargetType = "{x:Type controls:AcrylicMenuItem}">
+                <Setter Property = "Background" Value                              = "Transparent" />
             </Style>
 
         </ResourceDictionary>

--- a/src/RepoM.App/App.xaml.cs
+++ b/src/RepoM.App/App.xaml.cs
@@ -8,20 +8,20 @@ using System.IO.Abstractions;
 using System.Threading;
 using System.Windows;
 using Hardcodet.Wpf.TaskbarNotification;
-using RepoM.Api.Git;
-using RepoM.Api.IO;
-using RepoM.App.i18n;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using RepoM.Api;
+using RepoM.Api.Git;
+using RepoM.Api.IO;
 using RepoM.Api.Plugins;
+using RepoM.App.i18n;
 using RepoM.App.Plugins;
+using RepoM.App.Services;
+using RepoM.App.Services.HotKey;
 using Serilog;
 using Serilog.Core;
-using ILogger = Microsoft.Extensions.Logging.ILogger;
-using RepoM.App.Services;
 using Container = SimpleInjector.Container;
-using RepoM.App.Services.HotKey;
-using RepoM.Api;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 /// <summary>
 /// Interaction logic for App.xaml
@@ -92,7 +92,7 @@ public partial class App : Application
 
         EnsureStartup ensureStartup = Bootstrapper.Container.GetInstance<EnsureStartup>();
         await ensureStartup.EnsureFilesAsync().ConfigureAwait(true);
-        
+
         UseRepositoryMonitor(Bootstrapper.Container);
 
         this._moduleService = Bootstrapper.Container.GetInstance<ModuleService>();

--- a/src/RepoM.App/App.xaml.cs
+++ b/src/RepoM.App/App.xaml.cs
@@ -35,6 +35,9 @@ public partial class App : Application
     private HotKeyService? _hotKeyService;
     private WindowSizeService? _windowSizeService;
 
+    /// <summary>
+    /// Main program start point
+    /// </summary>
     [STAThread]
     public static void Main()
     {
@@ -49,6 +52,10 @@ public partial class App : Application
         app.Run();
     }
 
+    /// <summary>
+    /// OnStartup event
+    /// </summary>
+    /// <param name="e"></param>
     protected override async void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
@@ -61,7 +68,7 @@ public partial class App : Application
             new FrameworkPropertyMetadata(System.Windows.Markup.XmlLanguage.GetLanguage(System.Globalization.CultureInfo.CurrentCulture.IetfLanguageTag)));
 
         Application.Current.Resources.MergedDictionaries[0] = ResourceDictionaryTranslationService.ResourceDictionary;
-        _notifyIcon = FindResource("NotifyIcon") as TaskbarIcon;
+        this._notifyIcon = FindResource("NotifyIcon") as TaskbarIcon;
 
         var fileSystem = new FileSystem();
 
@@ -88,34 +95,38 @@ public partial class App : Application
         
         UseRepositoryMonitor(Bootstrapper.Container);
 
-        _moduleService = Bootstrapper.Container.GetInstance<ModuleService>();
-        _hotKeyService = Bootstrapper.Container.GetInstance<HotKeyService>();
-        _windowSizeService = Bootstrapper.Container.GetInstance<WindowSizeService>();
+        this._moduleService = Bootstrapper.Container.GetInstance<ModuleService>();
+        this._hotKeyService = Bootstrapper.Container.GetInstance<HotKeyService>();
+        this._windowSizeService = Bootstrapper.Container.GetInstance<WindowSizeService>();
 
-        _hotKeyService.Register();
-        _windowSizeService.Register();
+        this._hotKeyService.Register();
+        this._windowSizeService.Register();
 
         try
         {
-            await _moduleService.StartAsync().ConfigureAwait(false); // don't care about ui thread
+            await this._moduleService.StartAsync().ConfigureAwait(false); // don't care about ui thread
         }
         catch (Exception exception)
         {
             logger.LogError(exception, "Could not start all modules.");
         }
     }
-    
+
+    /// <summary>
+    /// OnExit Event
+    /// </summary>
+    /// <param name="e"></param>
     protected override void OnExit(ExitEventArgs e)
     {
-        _windowSizeService?.Unregister();
-        
-        _moduleService?.StopAsync().GetAwaiter().GetResult();
+        this._windowSizeService?.Unregister();
 
-        _hotKeyService?.Unregister();
+        this._moduleService?.StopAsync().GetAwaiter().GetResult();
 
-// #pragma warning disable CA1416 // Validate platform compatibility
-        _notifyIcon?.Dispose();
-// #pragma warning restore CA1416 // Validate platform compatibility
+        this._hotKeyService?.Unregister();
+
+        // #pragma warning disable CA1416 // Validate platform compatibility
+        this._notifyIcon?.Dispose();
+        // #pragma warning restore CA1416 // Validate platform compatibility
 
         ReleaseAndDisposeMutex();
 
@@ -199,5 +210,5 @@ public partial class App : Application
         }
     }
 
-    public static string? AvailableUpdate { get; private set; } = null;
+    public static string? AvailableUpdate { get; private set; }
 }

--- a/src/RepoM.App/Controls/AcrylicMenuItem.cs
+++ b/src/RepoM.App/Controls/AcrylicMenuItem.cs
@@ -14,12 +14,12 @@ public class AcrylicMenuItem : MenuItem
     {
         base.OnSubmenuOpened(e);
 
-        Dispatcher.BeginInvoke((Action)BlurSubMenu);
+        this.Dispatcher.BeginInvoke((Action)this.BlurSubMenu);
     }
 
     private void BlurSubMenu()
     {
-        DependencyObject firstSubItem = ItemContainerGenerator.ContainerFromIndex(0);
+        DependencyObject firstSubItem = this.ItemContainerGenerator.ContainerFromIndex(0);
 
         if (firstSubItem == null)
         {

--- a/src/RepoM.App/Controls/ZTextBox.cs
+++ b/src/RepoM.App/Controls/ZTextBox.cs
@@ -5,6 +5,16 @@ using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Input;
 
+/// <summary>
+/// The ZTextBox class is a custom control that extends the TextBox class in WPF. It adds additional functionality to handle specific key events. Here's a brief explanation:
+/// •	Namespace: RepoM.App.Controls
+/// •	Base Class: TextBox
+/// •	Event: Finish - This event is triggered when certain keys (Down, Return, Enter) are pressed.
+/// •	Key Handling:
+/// •	Clears the text when the Escape key is pressed.
+/// •	Triggers the Finish event when any of the keys in the FinisherKeys list are pressed.
+/// This custom control can be useful in scenarios where you need to perform specific actions based on key presses within a text box.
+/// </summary>
 public class ZTextBox : TextBox
 {
     public event EventHandler? Finish;
@@ -15,19 +25,19 @@ public class ZTextBox : TextBox
 
         if (e.Key == Key.Escape)
         {
-            Clear();
+            this.Clear();
         }
 
         if (FinisherKeys.Contains(e.Key))
         {
-            Finish?.Invoke(this, EventArgs.Empty);
+            this.Finish?.Invoke(this, EventArgs.Empty);
         }
     }
 
-    private static List<Key> FinisherKeys { get; } = new(3)
-        {
+    private static List<Key> FinisherKeys { get; } =
+        [
             Key.Down,
             Key.Return,
             Key.Enter,
-        };
+        ];
 }

--- a/src/RepoM.App/Converters/UtcToHumanizedLocalDateTimeConverter.cs
+++ b/src/RepoM.App/Converters/UtcToHumanizedLocalDateTimeConverter.cs
@@ -5,18 +5,21 @@ using System.Globalization;
 using System.Windows.Data;
 using RepoM.Api.Common;
 
+/// <summary>
+/// The UtcToHumanizedLocalDateTimeConverter class is a WPF value converter that
+/// converts a UTC DateTime to a human-readable local time string.
+/// It implements the IValueConverter interface and uses a HardcodededMiniHumanizer to format the date.
+/// The Convert method handles the conversion, while the ConvertBack method is not implemented.
+/// </summary>
 public class UtcToHumanizedLocalDateTimeConverter : IValueConverter
 {
     private static readonly HardcodededMiniHumanizer _humanizer = new(SystemClock.Instance);
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        DateTime date = DateTime.SpecifyKind(DateTime.Parse(value?.ToString() ?? string.Empty), DateTimeKind.Utc).ToLocalTime();
+        var date = DateTime.SpecifyKind(DateTime.Parse(value?.ToString() ?? string.Empty, CultureInfo.InvariantCulture), DateTimeKind.Utc).ToLocalTime();
         return _humanizer.HumanizeTimestamp(date);
     }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
 }

--- a/src/RepoM.App/Converters/UtcToLocalDateTimeConverter.cs
+++ b/src/RepoM.App/Converters/UtcToLocalDateTimeConverter.cs
@@ -4,15 +4,30 @@ using System;
 using System.Globalization;
 using System.Windows.Data;
 
+/// <summary>
+/// Converts a UTC DateTime to local DateTime.
+/// </summary>
 public class UtcToLocalDateTimeConverter : IValueConverter
 {
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        return DateTime.SpecifyKind(DateTime.Parse(value?.ToString() ?? string.Empty), DateTimeKind.Utc).ToLocalTime();
-    }
+    /// <summary>
+    /// Converts a UTC DateTime to local DateTime.
+    /// </summary>
+    /// <param name="value">The UTC DateTime value to convert.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>A local DateTime value.</returns>
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        DateTime.SpecifyKind(DateTime.Parse(value?.ToString() ?? string.Empty, CultureInfo.InvariantCulture), DateTimeKind.Utc).ToLocalTime();
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
-    }
+    /// <summary>
+    /// Converts a value back. This method is not implemented.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>A converted value.</returns>
+    /// <exception cref="NotImplementedException">Always thrown.</exception>
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
 }

--- a/src/RepoM.App/MainWindow.xaml
+++ b/src/RepoM.App/MainWindow.xaml
@@ -1,96 +1,96 @@
 <fw:AcrylicWindow
-    x:Class="RepoM.App.MainWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:app="clr-namespace:RepoM.App"
-    xmlns:controls="clr-namespace:RepoM.App.Controls"
-    xmlns:converters="clr-namespace:RepoM.App.Converters"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:fw="clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
-    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
-    xmlns:viewModels="clr-namespace:RepoM.App.ViewModels"
-    Title="RepoM"
-    Width="360"
-    Height="800"
-    d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}"
-    fw:AcrylicWindow.Enabled="True"
-    fw:AcrylicWindow.FallbackColor="#303030"
-    fw:AcrylicWindow.TintColor="#101010"
-    fw:AcrylicWindow.TintOpacity="0.7"
-    BorderThickness="0"
-    ShowInTaskbar="False"
-    Style="{StaticResource MaterialDesignWindow}"
-    TextElement.FontSize="12"
-    TextElement.FontWeight="Regular"
-    TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-    TextOptions.TextFormattingMode="Ideal"
-    TextOptions.TextRenderingMode="Auto"
-    mc:Ignorable="d"
+    x:Class                        ="RepoM.App.MainWindow"
+    xmlns                          = "http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x                        = "http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:app                      = "clr-namespace:RepoM.App"
+    xmlns:controls                 = "clr-namespace:RepoM.App.Controls"
+    xmlns:converters               = "clr-namespace:RepoM.App.Converters"
+    xmlns:d                        = "http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:fw                       = "clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
+    xmlns:materialDesign           = "http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc                       = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:metro                    = "http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:viewModels               = "clr-namespace:RepoM.App.ViewModels"
+    Title                          = "RepoM"
+    Width                          = "360"
+    Height                         = "800"
+    d:DataContext                  = "{d:DesignInstance viewModels:MainWindowViewModel}"
+    fw:AcrylicWindow.Enabled       = "True"
+    fw:AcrylicWindow.FallbackColor = "#303030"
+    fw:AcrylicWindow.TintColor     = "#101010"
+    fw:AcrylicWindow.TintOpacity   = "0.7"
+    BorderThickness                = "0"
+    ShowInTaskbar                  = "False"
+    Style                          = "{StaticResource MaterialDesignWindow}"
+    TextElement.FontSize           = "12"
+    TextElement.FontWeight         = "Regular"
+    TextElement.Foreground         = "{DynamicResource MaterialDesignBody}"
+    TextOptions.TextFormattingMode = "Ideal"
+    TextOptions.TextRenderingMode  = "Auto"
+    mc:Ignorable                   = "d"
     >
     <Window.Resources>
-        <converters:UtcToHumanizedLocalDateTimeConverter x:Key="UtcToHumanizedLocalDateTimeConverter" />
+        <converters:UtcToHumanizedLocalDateTimeConverter x:Key = "UtcToHumanizedLocalDateTimeConverter" />
     </Window.Resources>
-    <Grid Margin="12" Focusable="False">
+    <Grid Margin = "12" Focusable = "False">
 
         <materialDesign:Transitioner
-            Name="transitionerMain"
-            Focusable="False"
-            SelectedIndex="0"
+            Name          = "transitionerMain"
+            Focusable     = "False"
+            SelectedIndex = "0"
             >
 
             <Grid>
                 <TextBlock
-                    x:Name="tbNoRepositories"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Focusable="False"
-                    FontSize="15"
-                    Foreground="Gray"
-                    Text="{DynamicResource EmptyHint}"
-                    TextAlignment="Center"
-                    TextWrapping="Wrap"
+                      x:Name              = "tbNoRepositories"
+                      HorizontalAlignment = "Center"
+                      VerticalAlignment   = "Center"
+                      Focusable           = "False"
+                      FontSize            = "15"
+                      Foreground          = "Gray"
+                      Text                = "{DynamicResource EmptyHint}"
+                      TextAlignment       = "Center"
+                      TextWrapping        = "Wrap"
                     />
 
-                <DockPanel x:Name="dockMain" Focusable="False">
-                    <Grid DockPanel.Dock="Top" Focusable="False">
+                <DockPanel x:Name         = "dockMain" Focusable = "False">
+                <Grid      DockPanel.Dock = "Top" Focusable      = "False">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="*" />
+                            <RowDefinition Height = "*" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width = "*" />
+                            <ColumnDefinition Width = "Auto" />
+                            <ColumnDefinition Width = "Auto" />
                         </Grid.ColumnDefinitions>
                         <Grid
-                            Grid.Column="0"
-                            HorizontalAlignment="Stretch"
-                            Focusable="False"
+                            Grid.Column         = "0"
+                            HorizontalAlignment = "Stretch"
+                            Focusable           = "False"
                             >
                             <controls:ZTextBox
-                                x:Name="txtFilter"
-                                VerticalAlignment="Top"
-                                Finish="TxtFilter_Finish"
-                                FontSize="17"
-                                TextChanged="OnTxtFilterTextChanged"
+                                x:Name            = "txtFilter"
+                                VerticalAlignment = "Top"
+                                Finish            = "TxtFilter_Finish"
+                                FontSize          = "17"
+                                TextChanged       = "OnTxtFilterTextChanged"
                                 />
 
                             <TextBlock
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Focusable="False"
-                                FontSize="15"
-                                Foreground="Gray"
-                                IsHitTestVisible="False"
-                                Text="{DynamicResource SearchWin}"
+                                HorizontalAlignment = "Left"
+                                VerticalAlignment   = "Center"
+                                Focusable           = "False"
+                                FontSize            = "15"
+                                Foreground          = "Gray"
+                                IsHitTestVisible    = "False"
+                                Text                = "{DynamicResource SearchWin}"
                                 >
                                 <TextBlock.Style>
-                                    <Style TargetType="{x:Type TextBlock}">
-                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style  TargetType = "{x:Type TextBlock}">
+                                    <Setter Property   = "Visibility" Value = "Collapsed" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Text, ElementName=txtFilter}" Value="">
-                                                <Setter Property="Visibility" Value="Visible" />
+                                            <DataTrigger Binding  = "{Binding Text, ElementName=txtFilter}" Value = "">
+                                            <Setter      Property = "Visibility" Value                            = "Visible" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -99,170 +99,170 @@
 
                         </Grid>
                         <Button
-                            Name="MenuButton"
-                            Grid.Column="1"
-                            Width="32"
-                            Margin="10,0,0,0"
-                            Padding="0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Background="#00FFF0F0"
-                            Click="MenuButton_Click"
-                            Content="☰"
-                            Cursor="Arrow"
-                            FontSize="17"
-                            Foreground="{DynamicResource MaterialDesignBody}"
-                            Style="{DynamicResource MaterialDesignFlatButton}"
+                            Name                = "MenuButton"
+                            Grid.Column         = "1"
+                            Width               = "32"
+                            Margin              = "10,0,0,0"
+                            Padding             = "0"
+                            HorizontalAlignment = "Center"
+                            VerticalAlignment   = "Center"
+                            Background          = "#00FFF0F0"
+                            Click               = "MenuButton_Click"
+                            Content             = "☰"
+                            Cursor              = "Arrow"
+                            FontSize            = "17"
+                            Foreground          = "{DynamicResource MaterialDesignBody}"
+                            Style               = "{DynamicResource MaterialDesignFlatButton}"
                             >
                             <Button.Resources>
-                                <Style x:Key="DatePickerStyle" TargetType="{x:Type controls:AcrylicMenuItem}">
-                                    <Setter Property="Header" Value="coen" />
-                                    <Setter Property="IsChecked" Value="{Binding Selected2}" />
+                                <Style  x:Key    = "DatePickerStyle" TargetType = "{x:Type controls:AcrylicMenuItem}">
+                                <Setter Property = "Header" Value               = "coen" />
+                                <Setter Property = "IsChecked" Value            = "{Binding Selected2}" />
                                 </Style>
                             </Button.Resources>
                             <Button.ContextMenu>
                                 <controls:AcrylicContextMenu x:Name="SettingsMenu">
-                                    <controls:AcrylicMenuItem Header="{DynamicResource ManageRepos}">
-                                        <controls:AcrylicMenuItem
-                                            x:Name="ScanMenuItem"
-                                            Click="ScanButton_Click"
-                                            Header="{DynamicResource ScanComputer}"
-                                            />
-                                        <controls:AcrylicMenuItem Click="ClearButton_Click" Header="{DynamicResource Clear}" />
+                                <controls:AcrylicMenuItem Header="{DynamicResource ManageRepos}">
+                                <controls:AcrylicMenuItem
+                                            x:Name = "ScanMenuItem"
+                                            Click  = "ScanButton_Click"
+                                            Header = "{DynamicResource ScanComputer}"
+                                        />
+                                        <controls:AcrylicMenuItem Click = "ClearButton_Click" Header = "{DynamicResource Clear}" />
                                         <Separator />
-                                        <controls:AcrylicMenuItem Click="CustomizeContextMenu_Click" Header="{DynamicResource CustomizeRepositoryActions}" />
+                                        <controls:AcrylicMenuItem Click = "CustomizeContextMenu_Click" Header = "{DynamicResource CustomizeRepositoryActions}" />
                                         <Separator />
-                                        <controls:AcrylicMenuItem Click="ResetIgnoreRulesButton_Click" Header="{DynamicResource ResetIgnoreRules}" />
+                                    <controls:AcrylicMenuItem Click="ResetIgnoreRulesButton_Click" Header="{DynamicResource ResetIgnoreRules}" />
                                     </controls:AcrylicMenuItem>
 
-                                    <controls:AcrylicMenuItem Header="Ordering" ItemsSource="{Binding Path=Orderings}">
-                                        <!-- <controls:AcrylicMenuItem.Template> -->
-                                        <!--     <ControlTemplate TargetType="{x:Type MenuItem}"> -->
-                                        <!--         ~1~ <Separator Style="{DynamicResource {x:Static MenuItem.SeparatorStyleKey}}"/> @1@ -->
-                                        <!--  <controls:AcrylicMenuItem Header="xxxxxxx"  -->
+                                         <controls:AcrylicMenuItem Header="Ordering" ItemsSource="{Binding Path=Orderings}">
+                                    <!-- <controls:AcrylicMenuItem.Template> -->
+                                        <!-- <ControlTemplate TargetType      = "{x:Type MenuItem}"> -->
+                                        <!-- ~1~ <Separator Style             = "{DynamicResource {x:Static MenuItem.SeparatorStyleKey}}"/> @1@ -->
+                                        <!-- <controls:AcrylicMenuItem Header = "xxxxxxx"  -->
                                         <!--    -->
                                         <!--  />  -->
                                         <!--     </ControlTemplate> -->
                                         <!-- </controls:AcrylicMenuItem.Template> -->
-                                        <controls:AcrylicMenuItem.ItemContainerStyle>
+                                             <controls:AcrylicMenuItem.ItemContainerStyle>
                                             <Style>
-                                                <Setter Property="controls:AcrylicMenuItem.Template">
+                                                <Setter Property = "controls:AcrylicMenuItem.Template">
                                                     <Setter.Value>
-                                                        <ControlTemplate TargetType="{x:Type MenuItem}">
+                                                        <ControlTemplate TargetType = "{x:Type MenuItem}">
                                                             <!-- <Separator/> -->
                                                             <controls:AcrylicMenuItem
-                                                                Header="{Binding Header}"
-                                                                IsCheckable="{Binding IsCheckable}"
-                                                                IsChecked="{Binding IsChecked}"
+                                                                Header      = "{Binding Header}"
+                                                                IsCheckable = "{Binding IsCheckable}"
+                                                                IsChecked   = "{Binding IsChecked}"
                                                                 />
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
                                             </Style>
-                                            <!--     ~1~ <Style TargetType="{x:Type MenuItem}"> @1@ -->
+                                            <!-- ~1~ <Style TargetType = "{x:Type MenuItem}"> @1@ -->
                                             <!--  ~1~   @1@  -->
                                             <!--     ~1~ </Style> @1@ -->
-                                        </controls:AcrylicMenuItem.ItemContainerStyle>
+                                             </controls:AcrylicMenuItem.ItemContainerStyle>
                                         <!-- <controls:AcrylicMenuItem.ItemTemplate> -->
                                         <!--     <DataTemplate> -->
-                                        <!--         ~1~ <controls:AcrylicMenuItem Header="{Binding}" IsCheckable="True" IsChecked="{Binding AutoFetchAdequate}"/> @1@ -->
+                                        <!-- ~1~ <controls:AcrylicMenuItem Header = "{Binding}" IsCheckable = "True" IsChecked = "{Binding AutoFetchAdequate}"/> @1@ -->
                                         <!--    -->
-                                        <!--         ~1~ <controls:AcrylicMenuItem Header="{Binding}" Click="ResetIgnoreRulesButton_Click" /> @1@ -->
-                                        <!--         ~1~ <TextBlock Text="{Binding }"></TextBlock > @1@ -->
+                                        <!-- ~1~ <controls:AcrylicMenuItem Header = "{Binding}" Click = "ResetIgnoreRulesButton_Click" /> @1@ -->
+                                        <!-- ~1~ <TextBlock Text                  = "{Binding }"></TextBlock > @1@ -->
                                         <!--     </DataTemplate> -->
                                         <!-- </controls:AcrylicMenuItem.ItemTemplate> -->
 
-                                        <!-- <controls:AcrylicMenuItem Header="{DynamicResource ScanComputer}" Click="ScanButton_Click" x:Name=""/> -->
-                                        <!-- <controls:AcrylicMenuItem Header="{DynamicResource Clear}" Click="ClearButton_Click"/> -->
+                                        <!-- <controls:AcrylicMenuItem Header = "{DynamicResource ScanComputer}" Click = "ScanButton_Click" x:Name = ""/> -->
+                                        <!-- <controls:AcrylicMenuItem Header = "{DynamicResource Clear}" Click        = "ClearButton_Click"/> -->
                                         <!-- <Separator/> -->
-                                        <!-- <controls:AcrylicMenuItem Header="{DynamicResource CustomizeRepositoryActions}" Click="CustomizeContextMenu_Click" /> -->
+                                        <!-- <controls:AcrylicMenuItem Header = "{DynamicResource CustomizeRepositoryActions}" Click = "CustomizeContextMenu_Click" /> -->
                                         <!-- <Separator/> -->
-                                        <!-- <controls:AcrylicMenuItem Header="{DynamicResource ResetIgnoreRules}" Click="ResetIgnoreRulesButton_Click" /> -->
-                                    </controls:AcrylicMenuItem>
+                                    <!-- <controls:AcrylicMenuItem Header="{DynamicResource ResetIgnoreRules}" Click="ResetIgnoreRulesButton_Click" /> -->
+                                         </controls:AcrylicMenuItem>
 
                                     <controls:AcrylicMenuItem Header="Filters" ItemsSource="{Binding Path=Filters}">
-                                        <controls:AcrylicMenuItem.ItemContainerStyle>
+                                    <controls:AcrylicMenuItem.ItemContainerStyle>
                                             <Style>
-                                                <Setter Property="controls:AcrylicMenuItem.Template">
+                                                <Setter Property = "controls:AcrylicMenuItem.Template">
                                                     <Setter.Value>
-                                                        <ControlTemplate TargetType="{x:Type MenuItem}">
+                                                        <ControlTemplate TargetType = "{x:Type MenuItem}">
                                                             <controls:AcrylicMenuItem
-                                                                Header="{Binding Header}"
-                                                                IsCheckable="{Binding IsCheckable}"
-                                                                IsChecked="{Binding IsChecked}"
+                                                                Header      = "{Binding Header}"
+                                                                IsCheckable = "{Binding IsCheckable}"
+                                                                IsChecked   = "{Binding IsChecked}"
                                                                 />
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
                                             </Style>
-                                        </controls:AcrylicMenuItem.ItemContainerStyle>
+                                    </controls:AcrylicMenuItem.ItemContainerStyle>
                                     </controls:AcrylicMenuItem>
 
                                     <controls:AcrylicMenuItem Header="Plugins" ItemsSource="{Binding Path=Plugins}">
-                                        <controls:AcrylicMenuItem.ItemContainerStyle>
+                                    <controls:AcrylicMenuItem.ItemContainerStyle>
                                             <Style>
-                                                <Setter Property="controls:AcrylicMenuItem.Template">
+                                                <Setter Property = "controls:AcrylicMenuItem.Template">
                                                     <Setter.Value>
-                                                        <ControlTemplate TargetType="{x:Type MenuItem}">
+                                                        <ControlTemplate TargetType = "{x:Type MenuItem}">
                                                             <controls:AcrylicMenuItem
-                                                                Header="{Binding Header}"
-                                                                IsCheckable="{Binding IsCheckable}"
-                                                                IsChecked="{Binding IsChecked}"
+                                                                Header      = "{Binding Header}"
+                                                                IsCheckable = "{Binding IsCheckable}"
+                                                                IsChecked   = "{Binding IsChecked}"
                                                                 />
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
                                             </Style>
-                                        </controls:AcrylicMenuItem.ItemContainerStyle>
+                                    </controls:AcrylicMenuItem.ItemContainerStyle>
                                     </controls:AcrylicMenuItem>
 
                                     <controls:AcrylicMenuItem x:Name="AutoFetchMenuItem" Header="{DynamicResource AutoFetch}">
-                                        <controls:AcrylicMenuItem
-                                            Header="{DynamicResource Off}"
-                                            IsCheckable="True"
-                                            IsChecked="{Binding AutoFetchOff}"
+                                    <controls:AcrylicMenuItem
+                                            Header      = "{DynamicResource Off}"
+                                            IsCheckable = "True"
+                                            IsChecked   = "{Binding AutoFetchOff}"
                                             />
                                         <Separator />
                                         <MenuItem
-                                            Header="{DynamicResource Discretely}"
-                                            IsCheckable="True"
-                                            IsChecked="{Binding AutoFetchDiscretely}"
+                                            Header      = "{DynamicResource Discretely}"
+                                            IsCheckable = "True"
+                                            IsChecked   = "{Binding AutoFetchDiscretely}"
                                             />
                                         <controls:AcrylicMenuItem
-                                            Header="{DynamicResource Adequate}"
-                                            IsCheckable="True"
-                                            IsChecked="{Binding AutoFetchAdequate}"
+                                            Header      = "{DynamicResource Adequate}"
+                                            IsCheckable = "True"
+                                            IsChecked   = "{Binding AutoFetchAdequate}"
                                             />
                                         <controls:AcrylicMenuItem
-                                            Header="{DynamicResource Aggressive}"
-                                            IsCheckable="True"
-                                            IsChecked="{Binding AutoFetchAggressive}"
+                                            Header      = "{DynamicResource Aggressive}"
+                                            IsCheckable = "True"
+                                            IsChecked   = "{Binding AutoFetchAggressive}"
                                             />
                                     </controls:AcrylicMenuItem>
 
                                     <controls:AcrylicMenuItem Header="{DynamicResource Advanced}">
-                                        <controls:AcrylicMenuItem
-                                            Header="{DynamicResource PruneOnFetch}"
-                                            IsCheckable="True"
-                                            IsChecked="{Binding PruneOnFetch}"
+                                    <controls:AcrylicMenuItem
+                                            Header      = "{DynamicResource PruneOnFetch}"
+                                            IsCheckable = "True"
+                                            IsChecked   = "{Binding PruneOnFetch}"
                                             />
 
                                         <controls:AcrylicMenuItem Header="Query Parsers" ItemsSource="{Binding Path=QueryParsers}">
-                                            <controls:AcrylicMenuItem.ItemContainerStyle>
+                                        <controls:AcrylicMenuItem.ItemContainerStyle>
                                                 <Style>
-                                                    <Setter Property="controls:AcrylicMenuItem.Template">
+                                                    <Setter Property = "controls:AcrylicMenuItem.Template">
                                                         <Setter.Value>
-                                                            <ControlTemplate TargetType="{x:Type MenuItem}">
+                                                            <ControlTemplate TargetType = "{x:Type MenuItem}">
                                                                 <controls:AcrylicMenuItem
-                                                                    Header="{Binding Header}"
-                                                                    IsCheckable="{Binding IsCheckable}"
-                                                                    IsChecked="{Binding IsChecked}"
+                                                                    Header      = "{Binding Header}"
+                                                                    IsCheckable = "{Binding IsCheckable}"
+                                                                    IsChecked   = "{Binding IsChecked}"
                                                                     />
                                                             </ControlTemplate>
                                                         </Setter.Value>
                                                     </Setter>
                                                 </Style>
-                                            </controls:AcrylicMenuItem.ItemContainerStyle>
+                                        </controls:AcrylicMenuItem.ItemContainerStyle>
                                         </controls:AcrylicMenuItem>
 
 
@@ -271,163 +271,163 @@
                                     <Separator />
 
                                     <controls:AcrylicMenuItem Foreground="#FFED8888" Header="{DynamicResource PingBack}">
-                                        <controls:AcrylicMenuItem
-                                            Click="SponsorButton_Click"
-                                            Foreground="{DynamicResource MaterialDesignBody}"
-                                            Header="{DynamicResource Donate}"
+                                    <controls:AcrylicMenuItem
+                                            Click      = "SponsorButton_Click"
+                                            Foreground = "{DynamicResource MaterialDesignBody}"
+                                            Header     = "{DynamicResource Donate}"
                                             />
                                         <Separator />
                                         <controls:AcrylicMenuItem
-                                            Click="FollowButton_Click"
-                                            Foreground="{DynamicResource MaterialDesignBody}"
-                                            Header="{DynamicResource Follow}"
+                                            Click      = "FollowButton_Click"
+                                            Foreground = "{DynamicResource MaterialDesignBody}"
+                                            Header     = "{DynamicResource Follow}"
                                             />
                                         <controls:AcrylicMenuItem
-                                            Click="StarButton_Click"
-                                            Foreground="{DynamicResource MaterialDesignBody}"
-                                            Header="{DynamicResource Star}"
+                                            Click      = "StarButton_Click"
+                                            Foreground = "{DynamicResource MaterialDesignBody}"
+                                            Header     = "{DynamicResource Star}"
                                             />
                                     </controls:AcrylicMenuItem>
 
                                     <Separator />
 
-                                    <controls:AcrylicMenuItem Click="HelpButton_Click" Header="{DynamicResource Help}" />
+                                    <controls:AcrylicMenuItem Click = "HelpButton_Click" Header = "{DynamicResource Help}" />
 
                                 </controls:AcrylicContextMenu>
                             </Button.ContextMenu>
                         </Button>
                         <Button
-                            x:Name="UpdateButton"
-                            Grid.Column="2"
-                            Width="32"
-                            Margin="10,0,0,0"
-                            Padding="0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Background="#3000ff00"
-                            Click="UpdateButton_Click"
-                            Content="🡱"
-                            Cursor="Arrow"
-                            FontSize="17"
-                            Foreground="{DynamicResource MaterialDesignBody}"
-                            Style="{DynamicResource MaterialDesignFlatButton}"
-                            Visibility="Visible"
+                              x:Name              = "UpdateButton"
+                              Grid.Column         = "2"
+                              Width               = "32"
+                              Margin              = "10,0,0,0"
+                              Padding             = "0"
+                              HorizontalAlignment = "Center"
+                              VerticalAlignment   = "Center"
+                              Background          = "#3000ff00"
+                              Click               = "UpdateButton_Click"
+                              Content             = "🡱"
+                              Cursor              = "Arrow"
+                              FontSize            = "17"
+                              Foreground          = "{DynamicResource MaterialDesignBody}"
+                              Style               = "{DynamicResource MaterialDesignFlatButton}"
+                              Visibility          = "Visible"
                             />
                     </Grid>
 
                     <ListBox
-                        Name="lstRepositories"
-                        Margin="0,10,0,0"
-                        VerticalAlignment="Top"
-                        HorizontalContentAlignment="Stretch"
-                        VerticalContentAlignment="Top"
-                        ContextMenuOpening="LstRepositories_ContextMenuOpening"
-                        DockPanel.Dock="Top"
-                        KeyDown="LstRepositories_KeyDown"
-                        MouseDoubleClick="LstRepositories_MouseDoubleClick"
-                        ScrollViewer.CanContentScroll="False"
-                        SelectionMode="Single"
+                        Name                          = "lstRepositories"
+                        Margin                        = "0,10,0,0"
+                        VerticalAlignment             = "Top"
+                        HorizontalContentAlignment    = "Stretch"
+                        VerticalContentAlignment      = "Top"
+                        ContextMenuOpening            = "LstRepositories_ContextMenuOpening"
+                        DockPanel.Dock                = "Top"
+                        KeyDown                       = "LstRepositories_KeyDown"
+                        MouseDoubleClick              = "LstRepositories_MouseDoubleClick"
+                        ScrollViewer.CanContentScroll = "False"
+                        SelectionMode                 = "Single"
                         >
                         <ListBox.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" />
+                                <VirtualizingStackPanel IsVirtualizing = "True" VirtualizationMode = "Recycling" />
                             </ItemsPanelTemplate>
                         </ListBox.ItemsPanel>
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel>
-                                    <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation = "Horizontal">
                                         <TextBlock
-                                            Margin="8,3,0,3"
-                                            Text="📌"
-                                            TextElement.FontSize="14"
-                                            Visibility="{Binding Path=IsPinned, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Margin               = "8,3,0,3"
+                                            Text                 = "📌"
+                                            TextElement.FontSize = "14"
+                                            Visibility           = "{Binding Path=IsPinned, Converter={StaticResource BooleanToVisibilityConverter}}"
                                             />
                                         <TextBlock
-                                            Margin="8,3,8,3"
-                                            Foreground="{DynamicResource AccentColorBrush}"
-                                            Text="{Binding Name}"
-                                            TextElement.FontSize="17"
-                                            ToolTip="{Binding Path}"
+                                            Margin               = "8,3,8,3"
+                                            Foreground           = "{DynamicResource AccentColorBrush}"
+                                            Text                 = "{Binding Name}"
+                                            TextElement.FontSize = "17"
+                                            ToolTip              = "{Binding Path}"
                                             />
                                     </StackPanel>
                                     <TextBlock
-                                        Margin="8,3,8,3"
-                                        FontSize="13.5"
-                                        Text="{Binding CurrentBranch}"
-                                        Visibility="{Binding Path=IsNotBare, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Margin     = "8,3,8,3"
+                                        FontSize   = "13.5"
+                                        Text       = "{Binding CurrentBranch}"
+                                        Visibility = "{Binding Path=IsNotBare, Converter={StaticResource BooleanToVisibilityConverter}}"
                                         />
-                                    <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation = "Horizontal">
 
                                         <Border
-                                            Margin="8,5,8,3"
-                                            Padding="6,2,6,2"
-                                            HorizontalAlignment="Left"
-                                            Background="#14FFFFFF"
-                                            BorderThickness="0"
-                                            CornerRadius="5"
+                                            Margin              = "8,5,8,3"
+                                            Padding             = "6,2,6,2"
+                                            HorizontalAlignment = "Left"
+                                            Background          = "#14FFFFFF"
+                                            BorderThickness     = "0"
+                                            CornerRadius        = "5"
                                             >
                                             <TextBlock
-                                                FontFamily="Source Code Pro"
-                                                FontSize="13.5"
-                                                Text="{Binding Status}"
+                                                FontFamily = "Source Code Pro"
+                                                FontSize   = "13.5"
+                                                Text       = "{Binding Status}"
                                                 >
                                                 <TextBlock.ToolTip>
-                                                    <TextBlock Text="{Binding UpdateStampUtc, StringFormat=HH:mm:ss, Converter={StaticResource UtcToHumanizedLocalDateTimeConverter}}" />
+                                                    <TextBlock Text = "{Binding UpdateStampUtc, StringFormat=HH:mm:ss, Converter={StaticResource UtcToHumanizedLocalDateTimeConverter}}" />
                                                 </TextBlock.ToolTip>
                                             </TextBlock>
                                         </Border>
-                                        <StackPanel Orientation="Horizontal">
-                                            <ItemsControl Grid.Column="0" ItemsSource="{Binding Tags}">
+                                        <StackPanel   Orientation = "Horizontal">
+                                        <ItemsControl Grid.Column = "0" ItemsSource = "{Binding Tags}">
                                                 <ItemsControl.ItemsPanel>
                                                     <ItemsPanelTemplate>
-                                                        <StackPanel Orientation="Horizontal" />
+                                                        <StackPanel Orientation = "Horizontal" />
                                                     </ItemsPanelTemplate>
                                                 </ItemsControl.ItemsPanel>
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
-                                                        <!-- <Button Content="{Binding Tag}" /> -->
+                                                        <!-- <Button Content = "{Binding Tag}" /> -->
                                                         <!--  screenshot 1  -->
-                                                        <!--  <Border Margin="8, 5, 8, 3"  -->
-                                                        <!--  Padding="6, 2, 6, 2"  -->
-                                                        <!--  BorderThickness="0"  -->
-                                                        <!--  Background="#FFED8888"  -->
-                                                        <!--  CornerRadius="5"  -->
-                                                        <!--  HorizontalAlignment="Left" >  -->
-                                                        <!--  <TextBlock Text="{Binding Tag}"  -->
-                                                        <!--  FontFamily="Source Code Pro"  -->
-                                                        <!--  FontSize="13.5" >  -->
+                                                        <!-- <Border Margin      = "8, 5, 8, 3"  -->
+                                                        <!-- Padding             = "6, 2, 6, 2"  -->
+                                                        <!-- BorderThickness     = "0"  -->
+                                                        <!-- Background          = "#FFED8888"  -->
+                                                        <!-- CornerRadius        = "5"  -->
+                                                        <!-- HorizontalAlignment = "Left" >  -->
+                                                        <!-- <TextBlock Text     = "{Binding Tag}"  -->
+                                                        <!-- FontFamily          = "Source Code Pro"  -->
+                                                        <!-- FontSize            = "13.5" >  -->
                                                         <!--     </TextBlock> -->
                                                         <!-- </Border> -->
 
                                                         <!--  screenshot 2  -->
-                                                        <!--  <Border Margin="8, 5, 8, 3"  -->
-                                                        <!--  Padding="6, 2, 6, 2"  -->
-                                                        <!--  BorderThickness="0"  -->
-                                                        <!--  Background="#14FFFFFF"  -->
-                                                        <!--  CornerRadius="5"  -->
-                                                        <!--  HorizontalAlignment="Left" >  -->
-                                                        <!--  <TextBlock Text="{Binding Tag}"  -->
-                                                        <!--  FontFamily="Source Code Pro"  -->
-                                                        <!--  Foreground="#FFED8888"  -->
-                                                        <!--  FontSize="13.5" >  -->
+                                                        <!-- <Border Margin      = "8, 5, 8, 3"  -->
+                                                        <!-- Padding             = "6, 2, 6, 2"  -->
+                                                        <!-- BorderThickness     = "0"  -->
+                                                        <!-- Background          = "#14FFFFFF"  -->
+                                                        <!-- CornerRadius        = "5"  -->
+                                                        <!-- HorizontalAlignment = "Left" >  -->
+                                                        <!-- <TextBlock Text     = "{Binding Tag}"  -->
+                                                        <!-- FontFamily          = "Source Code Pro"  -->
+                                                        <!-- Foreground          = "#FFED8888"  -->
+                                                        <!-- FontSize            = "13.5" >  -->
                                                         <!--                                         </TextBlock> -->
                                                         <!--                                     </Border> -->
 
                                                         <Border
-                                                            Margin="8,5,8,3"
-                                                            Padding="6,2,6,2"
-                                                            HorizontalAlignment="Left"
-                                                            Background="#14FFFFFF"
-                                                            BorderThickness="0"
-                                                            CornerRadius="5"
+                                                            Margin              = "8,5,8,3"
+                                                            Padding             = "6,2,6,2"
+                                                            HorizontalAlignment = "Left"
+                                                            Background          = "#14FFFFFF"
+                                                            BorderThickness     = "0"
+                                                            CornerRadius        = "5"
                                                             >
                                                             <TextBlock
-                                                                FontFamily="Source Code Pro"
-                                                                FontSize="13.5"
-                                                                Foreground="#FFED8888"
-                                                                Text="{Binding Tag}"
-                                                                />
+                                                                FontFamily = "Source Code Pro"
+                                                                FontSize   = "13.5"
+                                                                Foreground = "#FFED8888"
+                                                                Text       = "{Binding Tag}"
+                                                            />
                                                         </Border>
 
                                                     </DataTemplate>
@@ -440,30 +440,31 @@
                         </ListBox.ItemTemplate>
                         <ListBox.ContextMenu>
                             <controls:AcrylicContextMenu x:Name="mnuRepositoryContext">
-                                <!--<controls:AcrylicContextMenu.ItemsPanel>
+                            <!--<controls:AcrylicContextMenu.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" />
+                                        <VirtualizingStackPanel IsVirtualizing = "True" VirtualizationMode = "Recycling" />
                                     </ItemsPanelTemplate>
-                                </controls:AcrylicContextMenu.ItemsPanel>-->
+                            </controls:AcrylicContextMenu.ItemsPanel>-->
                             </controls:AcrylicContextMenu>
                         </ListBox.ContextMenu>
                     </ListBox>
                 </DockPanel>
             </Grid>
             <ScrollViewer>
-                <StackPanel DataContext="{Binding Help}">
+                <StackPanel DataContext = "{Binding Help}">
                     <TextBlock
-                        Text="{Binding Header}"
-                        TextElement.FontSize="12"
-                        TextElement.FontWeight="Bold"
-                        TextWrapping="Wrap"
+                        Text                   = "{Binding Header}"
+                        TextElement.FontSize   = "12"
+                        TextElement.FontWeight = "Bold"
+                        TextWrapping           = "Wrap"
                         />
                     <TextBlock
-                        Text="{Binding Description}"
-                        TextElement.FontSize="12"
-                        TextWrapping="Wrap"
+                        Text                 = "{Binding Description}"
+                        TextElement.FontSize = "12"
+                        TextWrapping         = "Wrap"
                         />
-                    <Button Command="{x:Static materialDesign:Transitioner.MovePreviousCommand}" Content="{DynamicResource GotIt}" />
+                    <Button Command = "{x:Static materialDesign:Transitioner.MovePreviousCommand}" 
+                            Content = "{DynamicResource GotIt}" />
                 </StackPanel>
             </ScrollViewer>
         </materialDesign:Transitioner>

--- a/src/RepoM.App/MainWindow.xaml
+++ b/src/RepoM.App/MainWindow.xaml
@@ -34,111 +34,114 @@
     </Window.Resources>
     <Grid Margin="12" Focusable="False">
 
-		<materialDesign:Transitioner Name="transitionerMain"
-									 SelectedIndex="0"
-									 Focusable="False">
+        <materialDesign:Transitioner
+            Name="transitionerMain"
+            Focusable="False"
+            SelectedIndex="0"
+            >
 
-			<Grid>
-				<TextBlock x:Name="tbNoRepositories"
-						   Text="{DynamicResource EmptyHint}"
-						   TextWrapping="Wrap"
-						   FontSize="15"
-						   HorizontalAlignment="Center"
-						   VerticalAlignment="Center"
-						   TextAlignment="Center"
-						   Focusable="False"
-						   Foreground="Gray">
-				</TextBlock>
+            <Grid>
+                <TextBlock
+                    x:Name="tbNoRepositories"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Focusable="False"
+                    FontSize="15"
+                    Foreground="Gray"
+                    Text="{DynamicResource EmptyHint}"
+                    TextAlignment="Center"
+                    TextWrapping="Wrap"
+                    />
 
-				<DockPanel x:Name="dockMain"
-						   Focusable="False">
-					<Grid
-						Focusable="False"
-						DockPanel.Dock="Top">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="*" />
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*" />
-							<ColumnDefinition Width="Auto" />
-							<ColumnDefinition Width="Auto" />
-						</Grid.ColumnDefinitions>
-						<Grid 
-							HorizontalAlignment="Stretch"
-							Focusable="False" 
-							Grid.Column="0"
-							>
-							<controls:ZTextBox x:Name="txtFilter"
-										   TextChanged="OnTxtFilterTextChanged"
-										   FontSize="17"
-										   VerticalAlignment="Top"
-										   Finish="TxtFilter_Finish">
-							</controls:ZTextBox>
+                <DockPanel x:Name="dockMain" Focusable="False">
+                    <Grid DockPanel.Dock="Top" Focusable="False">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid
+                            Grid.Column="0"
+                            HorizontalAlignment="Stretch"
+                            Focusable="False"
+                            >
+                            <controls:ZTextBox
+                                x:Name="txtFilter"
+                                VerticalAlignment="Top"
+                                Finish="TxtFilter_Finish"
+                                FontSize="17"
+                                TextChanged="OnTxtFilterTextChanged"
+                                />
 
-							<TextBlock IsHitTestVisible="False"
-								   Text="{DynamicResource SearchWin}"
-								   VerticalAlignment="Center"
-								   FontSize="15"
-								   HorizontalAlignment="Left"
-								   Focusable="False"
-								   Foreground="Gray">
-								<TextBlock.Style>
-									<Style TargetType="{x:Type TextBlock}">
-										<Setter Property="Visibility"
-											Value="Collapsed" />
-										<Style.Triggers>
-											<DataTrigger Binding="{Binding Text, ElementName=txtFilter}"
-													 Value="">
-												<Setter Property="Visibility"
-													Value="Visible" />
-											</DataTrigger>
-										</Style.Triggers>
-									</Style>
-								</TextBlock.Style>
-							</TextBlock>
+                            <TextBlock
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Focusable="False"
+                                FontSize="15"
+                                Foreground="Gray"
+                                IsHitTestVisible="False"
+                                Text="{DynamicResource SearchWin}"
+                                >
+                                <TextBlock.Style>
+                                    <Style TargetType="{x:Type TextBlock}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Text, ElementName=txtFilter}" Value="">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
 
-						</Grid>
-						<Button 
-							Name="MenuButton" 
-							Click="MenuButton_Click"
-							Content="☰" 
-							HorizontalAlignment="Center"
-							Padding="0"
-							VerticalAlignment="Center" 
-							Width="32" 
-							Cursor="Arrow" 
-							FontSize="17"
-							Background="#00FFF0F0"
-							Margin="10,0,0,0"
-							Grid.Column="1"
-							Foreground="{DynamicResource MaterialDesignBody}"
-							Style="{DynamicResource MaterialDesignFlatButton}">
-							<Button.Resources>
+                        </Grid>
+                        <Button
+                            Name="MenuButton"
+                            Grid.Column="1"
+                            Width="32"
+                            Margin="10,0,0,0"
+                            Padding="0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="#00FFF0F0"
+                            Click="MenuButton_Click"
+                            Content="☰"
+                            Cursor="Arrow"
+                            FontSize="17"
+                            Foreground="{DynamicResource MaterialDesignBody}"
+                            Style="{DynamicResource MaterialDesignFlatButton}"
+                            >
+                            <Button.Resources>
                                 <Style x:Key="DatePickerStyle" TargetType="{x:Type controls:AcrylicMenuItem}">
-                                    <Setter Property="IsChecked" Value="{Binding Selected2}"/>
-                                    <Setter Property="Header" Value="coen"/>
+                                    <Setter Property="Header" Value="coen" />
+                                    <Setter Property="IsChecked" Value="{Binding Selected2}" />
                                 </Style>
                             </Button.Resources>
                             <Button.ContextMenu>
-                                <controls:AcrylicContextMenu x:Name="SettingsMenu" >
-                                    <controls:AcrylicMenuItem Header="{DynamicResource ManageRepos}"  >
-										<controls:AcrylicMenuItem Header="{DynamicResource ScanComputer}" Click="ScanButton_Click" x:Name="ScanMenuItem"/>
-										<controls:AcrylicMenuItem Header="{DynamicResource Clear}" Click="ClearButton_Click"/>
-										<Separator/>
-										<controls:AcrylicMenuItem Header="{DynamicResource CustomizeRepositoryActions}" Click="CustomizeContextMenu_Click" />
-										<Separator/>
-										<controls:AcrylicMenuItem Header="{DynamicResource ResetIgnoreRules}" Click="ResetIgnoreRulesButton_Click" />
-									</controls:AcrylicMenuItem>
+                                <controls:AcrylicContextMenu x:Name="SettingsMenu">
+                                    <controls:AcrylicMenuItem Header="{DynamicResource ManageRepos}">
+                                        <controls:AcrylicMenuItem
+                                            x:Name="ScanMenuItem"
+                                            Click="ScanButton_Click"
+                                            Header="{DynamicResource ScanComputer}"
+                                            />
+                                        <controls:AcrylicMenuItem Click="ClearButton_Click" Header="{DynamicResource Clear}" />
+                                        <Separator />
+                                        <controls:AcrylicMenuItem Click="CustomizeContextMenu_Click" Header="{DynamicResource CustomizeRepositoryActions}" />
+                                        <Separator />
+                                        <controls:AcrylicMenuItem Click="ResetIgnoreRulesButton_Click" Header="{DynamicResource ResetIgnoreRules}" />
+                                    </controls:AcrylicMenuItem>
 
-                                    <controls:AcrylicMenuItem Header="Ordering"
-                                                              ItemsSource="{Binding Path=Orderings}"
-                                                              >
+                                    <controls:AcrylicMenuItem Header="Ordering" ItemsSource="{Binding Path=Orderings}">
                                         <!-- <controls:AcrylicMenuItem.Template> -->
                                         <!--     <ControlTemplate TargetType="{x:Type MenuItem}"> -->
                                         <!--         ~1~ <Separator Style="{DynamicResource {x:Static MenuItem.SeparatorStyleKey}}"/> @1@ -->
-                                        <!--         <controls:AcrylicMenuItem Header="xxxxxxx" -->
-                                        <!--                                    -->
-                                        <!--         /> -->
+                                        <!--  <controls:AcrylicMenuItem Header="xxxxxxx"  -->
+                                        <!--    -->
+                                        <!--  />  -->
                                         <!--     </ControlTemplate> -->
                                         <!-- </controls:AcrylicMenuItem.Template> -->
                                         <controls:AcrylicMenuItem.ItemContainerStyle>
@@ -147,24 +150,23 @@
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="{x:Type MenuItem}">
                                                             <!-- <Separator/> -->
-                                                            <controls:AcrylicMenuItem 
+                                                            <controls:AcrylicMenuItem
                                                                 Header="{Binding Header}"
                                                                 IsCheckable="{Binding IsCheckable}"
-																IsChecked="{Binding IsChecked}"
-                                                               
+                                                                IsChecked="{Binding IsChecked}"
                                                                 />
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
                                             </Style>
-                                                    <!--     ~1~ <Style TargetType="{x:Type MenuItem}"> @1@ -->
-                                        <!--     ~1~   @1@ -->
-                                        <!--     ~1~ </Style> @1@ -->
+                                            <!--     ~1~ <Style TargetType="{x:Type MenuItem}"> @1@ -->
+                                            <!--  ~1~   @1@  -->
+                                            <!--     ~1~ </Style> @1@ -->
                                         </controls:AcrylicMenuItem.ItemContainerStyle>
                                         <!-- <controls:AcrylicMenuItem.ItemTemplate> -->
                                         <!--     <DataTemplate> -->
                                         <!--         ~1~ <controls:AcrylicMenuItem Header="{Binding}" IsCheckable="True" IsChecked="{Binding AutoFetchAdequate}"/> @1@ -->
-                                        <!-- -->
+                                        <!--    -->
                                         <!--         ~1~ <controls:AcrylicMenuItem Header="{Binding}" Click="ResetIgnoreRulesButton_Click" /> @1@ -->
                                         <!--         ~1~ <TextBlock Text="{Binding }"></TextBlock > @1@ -->
                                         <!--     </DataTemplate> -->
@@ -178,16 +180,17 @@
                                         <!-- <controls:AcrylicMenuItem Header="{DynamicResource ResetIgnoreRules}" Click="ResetIgnoreRulesButton_Click" /> -->
                                     </controls:AcrylicMenuItem>
 
-                                    <controls:AcrylicMenuItem Header="Filters" ItemsSource="{Binding Path=Filters}" >
+                                    <controls:AcrylicMenuItem Header="Filters" ItemsSource="{Binding Path=Filters}">
                                         <controls:AcrylicMenuItem.ItemContainerStyle>
                                             <Style>
                                                 <Setter Property="controls:AcrylicMenuItem.Template">
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="{x:Type MenuItem}">
-                                                            <controls:AcrylicMenuItem 
+                                                            <controls:AcrylicMenuItem
                                                                 Header="{Binding Header}"
                                                                 IsCheckable="{Binding IsCheckable}"
-																IsChecked="{Binding IsChecked}"/>
+                                                                IsChecked="{Binding IsChecked}"
+                                                                />
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
@@ -195,16 +198,17 @@
                                         </controls:AcrylicMenuItem.ItemContainerStyle>
                                     </controls:AcrylicMenuItem>
 
-                                    <controls:AcrylicMenuItem Header="Plugins" ItemsSource="{Binding Path=Plugins}" >
+                                    <controls:AcrylicMenuItem Header="Plugins" ItemsSource="{Binding Path=Plugins}">
                                         <controls:AcrylicMenuItem.ItemContainerStyle>
                                             <Style>
                                                 <Setter Property="controls:AcrylicMenuItem.Template">
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="{x:Type MenuItem}">
-                                                            <controls:AcrylicMenuItem 
+                                                            <controls:AcrylicMenuItem
                                                                 Header="{Binding Header}"
                                                                 IsCheckable="{Binding IsCheckable}"
-                                                                IsChecked="{Binding IsChecked}"/>
+                                                                IsChecked="{Binding IsChecked}"
+                                                                />
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
@@ -212,28 +216,48 @@
                                         </controls:AcrylicMenuItem.ItemContainerStyle>
                                     </controls:AcrylicMenuItem>
 
-                                    <controls:AcrylicMenuItem Header="{DynamicResource AutoFetch}" x:Name="AutoFetchMenuItem" >
-										<controls:AcrylicMenuItem Header="{DynamicResource Off}" IsCheckable="True" IsChecked="{Binding AutoFetchOff}"/>
-										<Separator/>
-										<MenuItem Header="{DynamicResource Discretely}" IsCheckable="True" IsChecked="{Binding AutoFetchDiscretely}"/>
-										<controls:AcrylicMenuItem Header="{DynamicResource Adequate}" IsCheckable="True" IsChecked="{Binding AutoFetchAdequate}"/>
-										<controls:AcrylicMenuItem Header="{DynamicResource Aggressive}" IsCheckable="True" IsChecked="{Binding AutoFetchAggressive}"/>
-									</controls:AcrylicMenuItem>
+                                    <controls:AcrylicMenuItem x:Name="AutoFetchMenuItem" Header="{DynamicResource AutoFetch}">
+                                        <controls:AcrylicMenuItem
+                                            Header="{DynamicResource Off}"
+                                            IsCheckable="True"
+                                            IsChecked="{Binding AutoFetchOff}"
+                                            />
+                                        <Separator />
+                                        <MenuItem
+                                            Header="{DynamicResource Discretely}"
+                                            IsCheckable="True"
+                                            IsChecked="{Binding AutoFetchDiscretely}"
+                                            />
+                                        <controls:AcrylicMenuItem
+                                            Header="{DynamicResource Adequate}"
+                                            IsCheckable="True"
+                                            IsChecked="{Binding AutoFetchAdequate}"
+                                            />
+                                        <controls:AcrylicMenuItem
+                                            Header="{DynamicResource Aggressive}"
+                                            IsCheckable="True"
+                                            IsChecked="{Binding AutoFetchAggressive}"
+                                            />
+                                    </controls:AcrylicMenuItem>
 
-									<controls:AcrylicMenuItem Header="{DynamicResource Advanced}" >
-										<controls:AcrylicMenuItem Header="{DynamicResource PruneOnFetch}" IsCheckable="True" IsChecked="{Binding PruneOnFetch}" />
-                                        
-                                        <controls:AcrylicMenuItem Header="Query Parsers" ItemsSource="{Binding Path=QueryParsers}" >
+                                    <controls:AcrylicMenuItem Header="{DynamicResource Advanced}">
+                                        <controls:AcrylicMenuItem
+                                            Header="{DynamicResource PruneOnFetch}"
+                                            IsCheckable="True"
+                                            IsChecked="{Binding PruneOnFetch}"
+                                            />
+
+                                        <controls:AcrylicMenuItem Header="Query Parsers" ItemsSource="{Binding Path=QueryParsers}">
                                             <controls:AcrylicMenuItem.ItemContainerStyle>
                                                 <Style>
                                                     <Setter Property="controls:AcrylicMenuItem.Template">
                                                         <Setter.Value>
                                                             <ControlTemplate TargetType="{x:Type MenuItem}">
-                                                                <controls:AcrylicMenuItem 
+                                                                <controls:AcrylicMenuItem
                                                                     Header="{Binding Header}"
                                                                     IsCheckable="{Binding IsCheckable}"
                                                                     IsChecked="{Binding IsChecked}"
-                                                                />
+                                                                    />
                                                             </ControlTemplate>
                                                         </Setter.Value>
                                                     </Setter>
@@ -244,74 +268,95 @@
 
                                     </controls:AcrylicMenuItem>
 
-									<Separator/>
+                                    <Separator />
 
-									<controls:AcrylicMenuItem Header="{DynamicResource PingBack}" Foreground="#FFED8888">
-										<controls:AcrylicMenuItem Header="{DynamicResource Donate}" Click="SponsorButton_Click" Foreground="{DynamicResource MaterialDesignBody}"/>
-										<Separator/>
-										<controls:AcrylicMenuItem Header="{DynamicResource Follow}" Click="FollowButton_Click" Foreground="{DynamicResource MaterialDesignBody}"/>
-										<controls:AcrylicMenuItem Header="{DynamicResource Star}" Click="StarButton_Click" Foreground="{DynamicResource MaterialDesignBody}" />
-									</controls:AcrylicMenuItem>
+                                    <controls:AcrylicMenuItem Foreground="#FFED8888" Header="{DynamicResource PingBack}">
+                                        <controls:AcrylicMenuItem
+                                            Click="SponsorButton_Click"
+                                            Foreground="{DynamicResource MaterialDesignBody}"
+                                            Header="{DynamicResource Donate}"
+                                            />
+                                        <Separator />
+                                        <controls:AcrylicMenuItem
+                                            Click="FollowButton_Click"
+                                            Foreground="{DynamicResource MaterialDesignBody}"
+                                            Header="{DynamicResource Follow}"
+                                            />
+                                        <controls:AcrylicMenuItem
+                                            Click="StarButton_Click"
+                                            Foreground="{DynamicResource MaterialDesignBody}"
+                                            Header="{DynamicResource Star}"
+                                            />
+                                    </controls:AcrylicMenuItem>
 
-									<Separator/>
+                                    <Separator />
 
-									<controls:AcrylicMenuItem Header="{DynamicResource Help}" Click="HelpButton_Click"/>
+                                    <controls:AcrylicMenuItem Click="HelpButton_Click" Header="{DynamicResource Help}" />
 
-								</controls:AcrylicContextMenu>
-							</Button.ContextMenu>
-						</Button>
-						<Button
-							Content="🡱"
-							HorizontalAlignment="Center"
-							Padding="0"
-							VerticalAlignment="Center" 
-							Width="32" 
-							Cursor="Arrow" 
-							FontSize="17"
-							Background="#3000ff00"
-							Margin="10,0,0,0"
-							x:Name="UpdateButton"
-							Visibility="Visible"
-							Grid.Column="2"
-							Foreground="{DynamicResource MaterialDesignBody}"
-							Style="{DynamicResource MaterialDesignFlatButton}"
-							Click="UpdateButton_Click" />
-					</Grid>
+                                </controls:AcrylicContextMenu>
+                            </Button.ContextMenu>
+                        </Button>
+                        <Button
+                            x:Name="UpdateButton"
+                            Grid.Column="2"
+                            Width="32"
+                            Margin="10,0,0,0"
+                            Padding="0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="#3000ff00"
+                            Click="UpdateButton_Click"
+                            Content="🡱"
+                            Cursor="Arrow"
+                            FontSize="17"
+                            Foreground="{DynamicResource MaterialDesignBody}"
+                            Style="{DynamicResource MaterialDesignFlatButton}"
+                            Visibility="Visible"
+                            />
+                    </Grid>
 
-					<ListBox Name="lstRepositories"
-							 DockPanel.Dock="Top"
-							 HorizontalContentAlignment="Stretch"
-							 MouseDoubleClick="LstRepositories_MouseDoubleClick"
-							 KeyDown="LstRepositories_KeyDown"
-							 ContextMenuOpening="LstRepositories_ContextMenuOpening"
-							 VerticalAlignment="Top"
-							 VerticalContentAlignment="Top"
-							 SelectionMode="Single"
-							 Margin="0,10,0,0"
-							 ScrollViewer.CanContentScroll="False"
-							 >
-						<ListBox.ItemsPanel>
-							<ItemsPanelTemplate>
-								<VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" />
-							</ItemsPanelTemplate>
-						</ListBox.ItemsPanel>
-						<ListBox.ItemTemplate>
-							<DataTemplate>
-								<StackPanel>
+                    <ListBox
+                        Name="lstRepositories"
+                        Margin="0,10,0,0"
+                        VerticalAlignment="Top"
+                        HorizontalContentAlignment="Stretch"
+                        VerticalContentAlignment="Top"
+                        ContextMenuOpening="LstRepositories_ContextMenuOpening"
+                        DockPanel.Dock="Top"
+                        KeyDown="LstRepositories_KeyDown"
+                        MouseDoubleClick="LstRepositories_MouseDoubleClick"
+                        ScrollViewer.CanContentScroll="False"
+                        SelectionMode="Single"
+                        >
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
                                     <StackPanel Orientation="Horizontal">
-                                        <TextBlock Margin="8,3,0,3" TextElement.FontSize="14" Text="📌" 
-                                                   Visibility="{Binding Path=IsPinned, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                        <TextBlock Text="{Binding Name}"
-                                                   ToolTip="{Binding Path}"
-                                                   TextElement.FontSize="17"
-                                                   Foreground="{DynamicResource AccentColorBrush}"
-                                                   Margin="8, 3, 8, 3" />
+                                        <TextBlock
+                                            Margin="8,3,0,3"
+                                            Text="📌"
+                                            TextElement.FontSize="14"
+                                            Visibility="{Binding Path=IsPinned, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            />
+                                        <TextBlock
+                                            Margin="8,3,8,3"
+                                            Foreground="{DynamicResource AccentColorBrush}"
+                                            Text="{Binding Name}"
+                                            TextElement.FontSize="17"
+                                            ToolTip="{Binding Path}"
+                                            />
                                     </StackPanel>
-									<TextBlock Text="{Binding CurrentBranch}"
-                                               FontSize="13.5"
-                                               Margin="8, 3, 8, 3" 
-                                               Visibility="{Binding Path=IsNotBare, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                               />
+                                    <TextBlock
+                                        Margin="8,3,8,3"
+                                        FontSize="13.5"
+                                        Text="{Binding CurrentBranch}"
+                                        Visibility="{Binding Path=IsNotBare, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        />
                                     <StackPanel Orientation="Horizontal">
 
                                         <Border
@@ -336,7 +381,7 @@
                                             <ItemsControl Grid.Column="0" ItemsSource="{Binding Tags}">
                                                 <ItemsControl.ItemsPanel>
                                                     <ItemsPanelTemplate>
-                                                        <StackPanel Orientation="Horizontal"/>
+                                                        <StackPanel Orientation="Horizontal" />
                                                     </ItemsPanelTemplate>
                                                 </ItemsControl.ItemsPanel>
                                                 <ItemsControl.ItemTemplate>
@@ -391,35 +436,38 @@
                                         </StackPanel>
                                     </StackPanel>
                                 </StackPanel>
-							</DataTemplate>
-						</ListBox.ItemTemplate>
-						<ListBox.ContextMenu>
-							<controls:AcrylicContextMenu x:Name="mnuRepositoryContext" >
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                        <ListBox.ContextMenu>
+                            <controls:AcrylicContextMenu x:Name="mnuRepositoryContext">
                                 <!--<controls:AcrylicContextMenu.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" />
                                     </ItemsPanelTemplate>
                                 </controls:AcrylicContextMenu.ItemsPanel>-->
                             </controls:AcrylicContextMenu>
-						</ListBox.ContextMenu>
-					</ListBox>
-				</DockPanel>
-			</Grid>
-			<ScrollViewer>
+                        </ListBox.ContextMenu>
+                    </ListBox>
+                </DockPanel>
+            </Grid>
+            <ScrollViewer>
                 <StackPanel DataContext="{Binding Help}">
-                    <TextBlock TextWrapping="Wrap"
-                               TextElement.FontWeight="Bold"
-                               TextElement.FontSize="12" 
-                               Text="{Binding Header}"/>
-					<TextBlock TextWrapping="Wrap"
-                               TextElement.FontSize="12" 
-                               Text="{Binding Description}" />
-					<Button Command="{x:Static materialDesign:Transitioner.MovePreviousCommand}"
-							Content="{DynamicResource GotIt}"></Button>
-				</StackPanel>
-			</ScrollViewer>
-		</materialDesign:Transitioner>
+                    <TextBlock
+                        Text="{Binding Header}"
+                        TextElement.FontSize="12"
+                        TextElement.FontWeight="Bold"
+                        TextWrapping="Wrap"
+                        />
+                    <TextBlock
+                        Text="{Binding Description}"
+                        TextElement.FontSize="12"
+                        TextWrapping="Wrap"
+                        />
+                    <Button Command="{x:Static materialDesign:Transitioner.MovePreviousCommand}" Content="{DynamicResource GotIt}" />
+                </StackPanel>
+            </ScrollViewer>
+        </materialDesign:Transitioner>
 
-	</Grid>
+    </Grid>
 
 </fw:AcrylicWindow>

--- a/src/RepoM.App/MainWindow.xaml
+++ b/src/RepoM.App/MainWindow.xaml
@@ -1,35 +1,38 @@
-﻿<fw:AcrylicWindow x:Class="RepoM.App.MainWindow"
-          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-          xmlns:fw="clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
-          mc:Ignorable="d"
-          xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-          xmlns:converters="clr-namespace:RepoM.App.Converters"
-          xmlns:controls="clr-namespace:RepoM.App.Controls"
-          xmlns:app="clr-namespace:RepoM.App"
-          xmlns:viewModels="clr-namespace:RepoM.App.ViewModels"
-          TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-          TextElement.FontWeight="Regular"
-          TextElement.FontSize="12"
-          TextOptions.TextFormattingMode="Ideal"
-          TextOptions.TextRenderingMode="Auto"
-          BorderThickness="0"
-          Title="RepoM"
-          Height="540"
-          Width="350"
-          ShowInTaskbar="False"
-          fw:AcrylicWindow.TintColor="#101010"
-          fw:AcrylicWindow.FallbackColor="#303030"
-          fw:AcrylicWindow.TintOpacity="0.7"
-          fw:AcrylicWindow.Enabled="True"
-          d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}">
-	<Window.Resources>
-		<converters:UtcToHumanizedLocalDateTimeConverter x:Key="UtcToHumanizedLocalDateTimeConverter" />
-	</Window.Resources>
-	<Grid Margin="12" 
-		  Focusable="False">
+<fw:AcrylicWindow
+    x:Class="RepoM.App.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:app="clr-namespace:RepoM.App"
+    xmlns:controls="clr-namespace:RepoM.App.Controls"
+    xmlns:converters="clr-namespace:RepoM.App.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:fw="clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:viewModels="clr-namespace:RepoM.App.ViewModels"
+    Title="RepoM"
+    Width="360"
+    Height="800"
+    d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}"
+    fw:AcrylicWindow.Enabled="True"
+    fw:AcrylicWindow.FallbackColor="#303030"
+    fw:AcrylicWindow.TintColor="#101010"
+    fw:AcrylicWindow.TintOpacity="0.7"
+    BorderThickness="0"
+    ShowInTaskbar="False"
+    Style="{StaticResource MaterialDesignWindow}"
+    TextElement.FontSize="12"
+    TextElement.FontWeight="Regular"
+    TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+    TextOptions.TextFormattingMode="Ideal"
+    TextOptions.TextRenderingMode="Auto"
+    mc:Ignorable="d"
+    >
+    <Window.Resources>
+        <converters:UtcToHumanizedLocalDateTimeConverter x:Key="UtcToHumanizedLocalDateTimeConverter" />
+    </Window.Resources>
+    <Grid Margin="12" Focusable="False">
 
 		<materialDesign:Transitioner Name="transitionerMain"
 									 SelectedIndex="0"
@@ -311,20 +314,24 @@
                                                />
                                     <StackPanel Orientation="Horizontal">
 
-                                        <Border Margin="8, 5, 8, 3"
-                                                Padding="6, 2, 6, 2"
-                                                BorderThickness="0"
-                                                Background="#14FFFFFF"
-                                                CornerRadius="5"
-                                                HorizontalAlignment="Left" >
-										    <TextBlock Text="{Binding Status}"
-                                                   FontFamily="Consolas"   
-                                                   FontSize="13.5" >
-											    <TextBlock.ToolTip>
-												    <TextBlock Text="{Binding UpdateStampUtc, StringFormat=HH:mm:ss, Converter={StaticResource UtcToHumanizedLocalDateTimeConverter}}"/>
-											    </TextBlock.ToolTip>
-									    </TextBlock>
-									    </Border>
+                                        <Border
+                                            Margin="8,5,8,3"
+                                            Padding="6,2,6,2"
+                                            HorizontalAlignment="Left"
+                                            Background="#14FFFFFF"
+                                            BorderThickness="0"
+                                            CornerRadius="5"
+                                            >
+                                            <TextBlock
+                                                FontFamily="Source Code Pro"
+                                                FontSize="13.5"
+                                                Text="{Binding Status}"
+                                                >
+                                                <TextBlock.ToolTip>
+                                                    <TextBlock Text="{Binding UpdateStampUtc, StringFormat=HH:mm:ss, Converter={StaticResource UtcToHumanizedLocalDateTimeConverter}}" />
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                        </Border>
                                         <StackPanel Orientation="Horizontal">
                                             <ItemsControl Grid.Column="0" ItemsSource="{Binding Tags}">
                                                 <ItemsControl.ItemsPanel>
@@ -334,42 +341,49 @@
                                                 </ItemsControl.ItemsPanel>
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
-                                                       <!-- <Button Content="{Binding Tag}" /> -->
-                                                               <!-- screenshot 1 -->
-                                                       <!-- <Border Margin="8, 5, 8, 3" -->
-                                                       <!--         Padding="6, 2, 6, 2" -->
-                                                       <!--         BorderThickness="0" -->
-                                                       <!--         Background="#FFED8888" -->
-                                                       <!--         CornerRadius="5" -->
-                                                       <!--         HorizontalAlignment="Left" > -->
-                                                       <!--     <TextBlock Text="{Binding Tag}" -->
-                                                       <!--                FontFamily="Consolas"  -->
-                                                       <!--                FontSize="13.5" > -->
-                                                       <!--     </TextBlock> -->
-                                                       <!-- </Border> -->
+                                                        <!-- <Button Content="{Binding Tag}" /> -->
+                                                        <!--  screenshot 1  -->
+                                                        <!--  <Border Margin="8, 5, 8, 3"  -->
+                                                        <!--  Padding="6, 2, 6, 2"  -->
+                                                        <!--  BorderThickness="0"  -->
+                                                        <!--  Background="#FFED8888"  -->
+                                                        <!--  CornerRadius="5"  -->
+                                                        <!--  HorizontalAlignment="Left" >  -->
+                                                        <!--  <TextBlock Text="{Binding Tag}"  -->
+                                                        <!--  FontFamily="Source Code Pro"  -->
+                                                        <!--  FontSize="13.5" >  -->
+                                                        <!--     </TextBlock> -->
+                                                        <!-- </Border> -->
 
-													   <!-- screenshot 2 -->
-                   <!--                                      <Border Margin="8, 5, 8, 3" -->
-                   <!--                                             Padding="6, 2, 6, 2" -->
-                   <!--                                             BorderThickness="0" -->
-                   <!--                                             Background="#14FFFFFF" -->
-                   <!--                                             CornerRadius="5" -->
-                   <!--                                             HorizontalAlignment="Left" > -->
-                   <!--                                         <TextBlock Text="{Binding Tag}" -->
-                   <!--                                                    FontFamily="Consolas"  -->
-																	  <!-- Foreground="#FFED8888" -->
-                   <!--                                                    FontSize="13.5" > -->
-                   <!--                                         </TextBlock> -->
-                   <!--                                     </Border> -->
+                                                        <!--  screenshot 2  -->
+                                                        <!--  <Border Margin="8, 5, 8, 3"  -->
+                                                        <!--  Padding="6, 2, 6, 2"  -->
+                                                        <!--  BorderThickness="0"  -->
+                                                        <!--  Background="#14FFFFFF"  -->
+                                                        <!--  CornerRadius="5"  -->
+                                                        <!--  HorizontalAlignment="Left" >  -->
+                                                        <!--  <TextBlock Text="{Binding Tag}"  -->
+                                                        <!--  FontFamily="Source Code Pro"  -->
+                                                        <!--  Foreground="#FFED8888"  -->
+                                                        <!--  FontSize="13.5" >  -->
+                                                        <!--                                         </TextBlock> -->
+                                                        <!--                                     </Border> -->
 
-                                                            <Border Margin="8, 5, 8, 3"
-                                                                   Padding="6, 2, 6, 2"
-                                                                   BorderThickness="0"
-                                                                   Background="#14FFFFFF"
-                                                                   CornerRadius="5"
-                                                                   HorizontalAlignment="Left" >
-                                                               <TextBlock Text="{Binding Tag}" FontFamily="Consolas" Foreground="#FFED8888" FontSize="13.5" />
-                                                           </Border>
+                                                        <Border
+                                                            Margin="8,5,8,3"
+                                                            Padding="6,2,6,2"
+                                                            HorizontalAlignment="Left"
+                                                            Background="#14FFFFFF"
+                                                            BorderThickness="0"
+                                                            CornerRadius="5"
+                                                            >
+                                                            <TextBlock
+                                                                FontFamily="Source Code Pro"
+                                                                FontSize="13.5"
+                                                                Foreground="#FFED8888"
+                                                                Text="{Binding Tag}"
+                                                                />
+                                                        </Border>
 
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>

--- a/src/RepoM.App/MainWindow.xaml.cs
+++ b/src/RepoM.App/MainWindow.xaml.cs
@@ -81,7 +81,7 @@ public partial class MainWindow
         InitializeComponent();
 
         SetAcrylicWindowStyle(this, AcrylicWindowStyle.None);
-        
+
         var orderingsViewModel = new OrderingsViewModel(repositoryComparerManager, threadDispatcher);
         var queryParsersViewModel = new QueryParsersViewModel(_repositoryFilteringManager, threadDispatcher);
         var filterViewModel = new FiltersViewModel(_repositoryFilteringManager, threadDispatcher);
@@ -102,7 +102,7 @@ public partial class MainWindow
             _monitor.OnScanStateChanged += OnScanStateChanged;
             ShowScanningState(_monitor.Scanning);
         }
-        
+
         lstRepositories.ItemsSource = aggregator.Repositories;
 
         var view = (ListCollectionView)CollectionViewSource.GetDefaultView(aggregator.Repositories);
@@ -219,7 +219,7 @@ public partial class MainWindow
             e.Handled = true;
         }
     }
-    
+
     private async Task<bool> LstRepositoriesContextMenuOpeningWrapperAsync(ContextMenu ctxMenu)
     {
         try
@@ -232,15 +232,15 @@ public partial class MainWindow
 
             ctxMenu.Items.Clear();
             ctxMenu.Items.Add(new AcrylicMenuItem
-                {
-                    Header = "Error",
-                    IsEnabled = false,
-                });
+            {
+                Header = "Error",
+                IsEnabled = false,
+            });
             ctxMenu.Items.Add(new AcrylicMenuItem
-                {
-                    Header = e.Message,
-                    IsEnabled = false,
-                });
+            {
+                Header = e.Message,
+                IsEnabled = false,
+            });
 
             return false;
         }
@@ -268,10 +268,10 @@ public partial class MainWindow
 
         ctxMenu.Items.Clear();
         ctxMenu.Items.Add(new AcrylicMenuItem
-            {
-                Header = "Loading ..",
-                IsEnabled = true,
-            });
+        {
+            Header = "Loading ..",
+            IsEnabled = true,
+        });
 
         await foreach (UserInterfaceRepositoryActionBase action in _userMenuActionFactory.CreateMenuAsync(vm.Repository).ConfigureAwait(true))
         {
@@ -308,7 +308,7 @@ public partial class MainWindow
 
         return true;
     }
-    
+
 
     private async void LstRepositories_KeyDown(object? sender, KeyEventArgs e)
     {
@@ -322,7 +322,7 @@ public partial class MainWindow
             {
                 Console.WriteLine(exception);
             }
-            
+
             return;
         }
 
@@ -350,7 +350,7 @@ public partial class MainWindow
             }
         }
     }
-   
+
     private async Task InvokeActionOnCurrentRepositoryAsync()
     {
         if (lstRepositories.SelectedItem is not RepositoryViewModel selectedView)
@@ -423,9 +423,9 @@ public partial class MainWindow
         if (_fileSystem.Directory.Exists(directoryName))
         {
             Process.Start(new ProcessStartInfo(directoryName)
-                {
-                    UseShellExecute = true,
-                });
+            {
+                UseShellExecute = true,
+            });
         }
     }
 
@@ -456,9 +456,9 @@ public partial class MainWindow
     private static void Navigate(string url)
     {
         Process.Start(new ProcessStartInfo(url)
-            {
-                UseShellExecute = true,
-            });
+        {
+            UseShellExecute = true,
+        });
     }
 
     private void PlaceFormByTaskBarLocation()
@@ -480,12 +480,12 @@ public partial class MainWindow
         var rightX = workArea.Width - width;
 
         return TaskBarLocator.GetTaskBarLocation(primaryScreen) switch
-            {
-                TaskBarLocator.TaskBarLocation.Top => new Point(rightX, topY),
-                TaskBarLocator.TaskBarLocation.Left => new Point(leftX, bottomY),
-                TaskBarLocator.TaskBarLocation.Bottom or TaskBarLocator.TaskBarLocation.Right => new Point(rightX, bottomY),
-                _ => new Point(rightX, bottomY),
-            };
+        {
+            TaskBarLocator.TaskBarLocation.Top => new Point(rightX, topY),
+            TaskBarLocator.TaskBarLocation.Left => new Point(leftX, bottomY),
+            TaskBarLocator.TaskBarLocation.Bottom or TaskBarLocator.TaskBarLocation.Right => new Point(rightX, bottomY),
+            _ => new Point(rightX, bottomY),
+        };
     }
 
     private void ShowUpdateIfAvailable()
@@ -519,7 +519,7 @@ public partial class MainWindow
                 {
                     return;
                 }
-                
+
                 // run actions in the UI async to not block it
                 if (repositoryAction.ExecutionCausesSynchronizing)
                 {
@@ -534,10 +534,10 @@ public partial class MainWindow
             };
 
         var item = new AcrylicMenuItem
-            {
-                Header = repositoryAction.Name,
-                IsEnabled = repositoryAction.CanExecute,
-            };
+        {
+            Header = repositoryAction.Name,
+            IsEnabled = repositoryAction.CanExecute,
+        };
         item.Click += new RoutedEventHandler(clickAction);
 
         // this is a deferred submenu. We want to make sure that the context menu can pop up
@@ -637,7 +637,7 @@ public partial class MainWindow
             {
                 item.SubmenuOpened -= SelfDetachingEventHandler;
                 item.Items.Clear();
-                
+
                 foreach (UserInterfaceRepositoryActionBase subAction in await deferredRepositoryAction.GetAsync().ConfigureAwait(true))
                 {
                     Control? controlItem = CreateMenuItemNewStyleAsync(subAction);
@@ -672,7 +672,7 @@ public partial class MainWindow
             // this is a template submenu item to enable submenus under the current
             // menu item. this item gets removed when the real subitems are created
             item.Items.Add("Loading..");
-            
+
             async void SelfDetachingEventHandler1(object _, RoutedEventArgs evtArgs)
             {
                 item.SubmenuOpened -= SelfDetachingEventHandler1;
@@ -827,7 +827,7 @@ public partial class MainWindow
         {
             return false;
         }
-        
+
         if (string.IsNullOrWhiteSpace(query))
         {
             return true;

--- a/src/RepoM.App/RepoM.App.csproj
+++ b/src/RepoM.App/RepoM.App.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentWPF" Version="0.10.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
-    <PackageReference Include="MaterialDesignThemes.MahApps" Version="0.3.0" />
+    <PackageReference Include="MaterialDesignThemes.MahApps" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Changelog: 
1. This updates MaterialDesignThemes.MahApps.
2. This now requires Material 3 so it makes the required changes in App.xaml and MainWindows.xaml in that regard.
3. I've also increased slightly the height of the MainWindow.
4. Font has been changed from the ugly Consolas to Source Code Pro (https://github.com/adobe-fonts/source-code-pro) which is more clear-looking. Presumably the installer will need to pack this font.
5. It also cleans up the files a bit and adds some clarifying comments.

⚠️ Note that this changes the look of the UI. I didn't change any of the colours myself, this is simply how Material 3 looks.
See below the new look. I'm not thrilled about it, but think it's an improvement over the old one.

**Dark Mode:**

![image](https://github.com/user-attachments/assets/e002c1b2-1409-40ac-ae66-8aebd39d2bee)


**Light Mode (does anyone still use this?):**

![image](https://github.com/user-attachments/assets/b98bd0cf-b3d3-47b1-8364-69f601001e5e)

ℹ️ Note: Ignore the top header, that's just from the VS XAML debugger.

**Old font (Consolas):**

![image](https://github.com/user-attachments/assets/d35916c0-92bd-420f-8a09-6624892fac8f)

**New font (Adobe Source Code Pro):**

![image](https://github.com/user-attachments/assets/3133ecbd-c3ed-408e-a367-bf6e67f94a18)

![image](https://github.com/user-attachments/assets/4dfafbc0-83e0-4aa8-b84e-59ba787f5e98)



