### PR TITLE
Update Default Configs

### DIFF
--- a/src/RepoM.ActionMenu.CodeGen/RepoM.ActionMenu.CodeGen.csproj
+++ b/src/RepoM.ActionMenu.CodeGen/RepoM.ActionMenu.CodeGen.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Broslyn" Version="1.2.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.291" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.337" />
     <PackageReference Include="Scriban" Version="5.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
   </ItemGroup>

--- a/src/RepoM.ActionMenu.Core/ActionMenu/Model/ActionMenus/BrowseRepository/RepositoryActionBrowseRepositoryV1Mapper.cs
+++ b/src/RepoM.ActionMenu.Core/ActionMenu/Model/ActionMenus/BrowseRepository/RepositoryActionBrowseRepositoryV1Mapper.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using RepoM.ActionMenu.Core.Model;
 using RepoM.ActionMenu.Interface.ActionMenuFactory;
 using RepoM.ActionMenu.Interface.UserInterface;
 using RepoM.ActionMenu.Interface.YamlModel;
@@ -21,25 +20,28 @@ internal class RepositoryActionBrowseRepositoryV1Mapper : ActionToRepositoryActi
             yield break;
         }
 
-        var name = await context.RenderStringAsync(action.Name).ConfigureAwait(false);
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            name = "Browse remote";
-        }
+        string menuTitle;
+        //var menuTitle = await context.RenderStringAsync(action.Name).ConfigureAwait(false);
+        //if (string.IsNullOrWhiteSpace(menuTitle))
+        //{
+        //    menuTitle = "🔗Github: ";
+        //}
 
         var forceSingle = await action.FirstOnly.EvaluateAsync(context).ConfigureAwait(false);
 
         if (repository.Remotes.Count == 1 || forceSingle)
         {
-            yield return new UserInterfaceRepositoryAction(name, repository)
+            menuTitle = "🔗Github: " + shorten_github_link(repository.Remotes[0].Url);
+            yield return new UserInterfaceRepositoryAction(menuTitle, repository)
             {
                 RepositoryCommand = new BrowseRepositoryCommand(repository.Remotes[0].Url),
             };
         }
         else
         {
+            menuTitle = "🔗GitHub remote repositories";  //🔗
             yield return new DeferredSubActionsUserInterfaceRepositoryAction(
-                name,
+                menuTitle,
                 repository,
                 context,
                 captureScope: false,
@@ -50,14 +52,19 @@ internal class RepositoryActionBrowseRepositoryV1Mapper : ActionToRepositoryActi
         }
     }
 
+    private static string shorten_github_link(string remoteUrl)
+    {
+        return remoteUrl.Replace("https://github.com/", "").Replace(".git", "").Trim();
+    }
+
     private static Task<UserInterfaceRepositoryActionBase[]> EnumerateRemotes(IRepository repository)
     {
         return Task.FromResult(repository.Remotes
             .Take(50)
-            .Select(remote => new UserInterfaceRepositoryAction(remote.Name, repository)
-                {
-                    RepositoryCommand = new BrowseRepositoryCommand(remote.Url),
-                })
+            .Select(remote => new UserInterfaceRepositoryAction(shorten_github_link(remote.Url), repository)
+            {
+                RepositoryCommand = new BrowseRepositoryCommand(remote.Url),
+            })
             .Cast<UserInterfaceRepositoryActionBase>()
             .ToArray());
     }

--- a/src/RepoM.ActionMenu.Core/ActionMenu/Model/ActionMenus/Pin/RepositoryActionPinV1.cs
+++ b/src/RepoM.ActionMenu.Core/ActionMenu/Model/ActionMenus/Pin/RepositoryActionPinV1.cs
@@ -6,7 +6,7 @@ using RepoM.ActionMenu.Interface.YamlModel.ActionMenus;
 using RepoM.ActionMenu.Interface.YamlModel.Templating;
 
 /// <summary>
-/// Action to pin (or unpin) the current repository. Pinning is not persistant and all pinned repositories will be cleared when RepoM exits.
+/// Action to pin (or unpin) the current repository. Pinning is not persistent and all pinned repositories will be cleared when RepoM exits.
 /// Pinning a repository allowed custom filtering, ordering and searching.
 /// </summary>
 [RepositoryAction(TYPE_VALUE)]
@@ -21,7 +21,7 @@ internal sealed class RepositoryActionPinV1 : IMenuAction, IContext, IName
     }
 
     /// <inheritdoc cref="IName.Name"/>
-    [Text("(Un)Pin repository")]
+    [Text("📌 Pin / Unpin Repo")]
     public Text Name { get; set; } = null!;
 
     /// <inheritdoc cref="IMenuAction.Active"/>
@@ -34,7 +34,7 @@ internal sealed class RepositoryActionPinV1 : IMenuAction, IContext, IName
     /// <summary>
     /// The pin mode `[Toggle, Pin, UnPin]`.
     /// </summary>
-    public PinMode? Mode { get; set; } // GitHub issue: https://github.com/coenm/RepoM/issues/87
+    public PinMode? Mode { get; set; } = PinMode.Toggle; // GitHub issue: https://github.com/coenm/RepoM/issues/87
 
     public override string ToString()
     {

--- a/src/RepoM.ActionMenu.Core/RepoM.ActionMenu.Core.csproj
+++ b/src/RepoM.ActionMenu.Core/RepoM.ActionMenu.Core.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Scriban" Version="5.10.0" />
     <PackageReference Include="SimpleInjector" Version="5.5.0" />
     <PackageReference Include="System.IO.Abstractions" Version="21.0.29" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RepoM.Api/Bootstrapper.cs
+++ b/src/RepoM.Api/Bootstrapper.cs
@@ -1,37 +1,29 @@
 namespace RepoM.Api;
 
-using Microsoft.Extensions.Logging;
-using RepoM.Api.Common;
-using RepoM.Api.IO;
-using RepoM.Api.Plugins;
-using SimpleInjector;
+using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System;
+using Microsoft.Extensions.Logging;
+using RepoM.Api.Common;
+using RepoM.Api.IO;
+using RepoM.Api.Plugins;
 using RepoM.Api.Plugins.SimpleInjector;
 using RepoM.Core.Plugin;
 using RepoM.Core.Plugin.Common;
 using RepoM.Core.Plugin.RepositoryOrdering.Configuration;
+using SimpleInjector;
 
-public class CoreBootstrapper
+public class CoreBootstrapper(IPluginFinder pluginFinder, IFileSystem fileSystem, IAppDataPathProvider appDataProvider, ILoggerFactory loggerFactory)
 {
-    private readonly IPluginFinder _pluginFinder;
-    private readonly IFileSystem _fileSystem;
-    private readonly IAppDataPathProvider _appDataProvider;
-    private readonly ILoggerFactory _loggerFactory;
+    private readonly IPluginFinder _pluginFinder = pluginFinder ?? throw new ArgumentNullException(nameof(pluginFinder));
+    private readonly IFileSystem _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    private readonly IAppDataPathProvider _appDataProvider = appDataProvider ?? throw new ArgumentNullException(nameof(appDataProvider));
+    private readonly ILoggerFactory _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
 
     private static readonly Assembly _thisAssembly = typeof(CoreBootstrapper).Assembly;
-
-    public CoreBootstrapper(IPluginFinder pluginFinder, IFileSystem fileSystem, IAppDataPathProvider appDataProvider, ILoggerFactory loggerFactory)
-    {
-        _pluginFinder = pluginFinder ?? throw new ArgumentNullException(nameof(pluginFinder));
-        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-        _appDataProvider = appDataProvider ?? throw new ArgumentNullException(nameof(appDataProvider));
-        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-    }
 
     public static void RegisterRepositoryScorerConfigurationsTypes(Container container)
     {

--- a/src/RepoM.Api/EnsureStartup.cs
+++ b/src/RepoM.Api/EnsureStartup.cs
@@ -7,16 +7,10 @@ using System.Threading.Tasks;
 using RepoM.Api.Resources;
 using RepoM.Core.Plugin.Common;
 
-public class EnsureStartup
+public class EnsureStartup(IFileSystem fileSystem, IAppDataPathProvider appDataProvider)
 {
-    private readonly IFileSystem _fileSystem;
-    private readonly IAppDataPathProvider _appDataProvider;
-
-    public EnsureStartup(IFileSystem fileSystem, IAppDataPathProvider appDataProvider)
-    {
-        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-        _appDataProvider = appDataProvider ?? throw new ArgumentNullException(nameof(appDataProvider));
-    }
+    private readonly IFileSystem _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    private readonly IAppDataPathProvider _appDataProvider = appDataProvider ?? throw new ArgumentNullException(nameof(appDataProvider));
 
     public async Task EnsureFilesAsync()
     {

--- a/src/RepoM.Api/Git/DefaultRepositoryMonitor.cs
+++ b/src/RepoM.Api/Git/DefaultRepositoryMonitor.cs
@@ -60,7 +60,7 @@ public class DefaultRepositoryMonitor : IRepositoryMonitor
         _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _autoFetchHandler = autoFetchHandler ?? throw new ArgumentNullException(nameof(autoFetchHandler));
-        _repositoryObservers = new Dictionary<string, IRepositoryObserver>();
+        _repositoryObservers = [];
         _storeFlushTimer = new Timer(RepositoryStoreFlushTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
     }
 
@@ -153,7 +153,7 @@ public class DefaultRepositoryMonitor : IRepositoryMonitor
     {
         _logger.LogTrace("ObserveRepositoryChanges start");
 
-        _detectors = new List<IRepositoryDetector>();
+        _detectors = [];
 
         foreach (var path in _pathProvider.GetPaths())
         {

--- a/src/RepoM.Api/RepoM.Api.csproj
+++ b/src/RepoM.Api/RepoM.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="System.IO.Abstractions" Version="21.0.29" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/RepoM.Api/Resources/RepoM.Filtering.yaml
+++ b/src/RepoM.Api/Resources/RepoM.Filtering.yaml
@@ -1,12 +1,3 @@
-All:
-  name: All
-  description: Private repositories
-  always-visible:
-    kind: query@1
-    query: RepoM OR is:pinned
-  filter:
-    kind: query@1
-    query:
 Private:
   name: Private
   description: Private repositories

--- a/src/RepoM.Api/Resources/RepoM.Filtering.yaml
+++ b/src/RepoM.Api/Resources/RepoM.Filtering.yaml
@@ -1,3 +1,21 @@
+All:
+  name: All
+  description: Private repositories
+  always-visible:
+    kind: query@1
+    query: RepoM OR is:pinned
+  filter:
+    kind: query@1
+    query:
+Private:
+  name: Private
+  description: Private repositories
+  always-visible:
+    kind: query@1
+    query: RepoM OR is:pinned
+  filter:
+    kind: query@1
+    query: tag:private
 Work:
   name: Work
   description: Work filtering
@@ -7,12 +25,3 @@ Work:
   filter:
     kind: query@1
     query: tag:work
-Private:
-  name: Private
-  description: Private repositories
-  always-visible:
-    kind: query@1
-    query: RepoM OR is:pinned
-  filter:
-    kind: query@1
-    query: (-tag:work OR tag:private)

--- a/src/RepoM.Api/Resources/RepoM.Sorting.yaml
+++ b/src/RepoM.Api/Resources/RepoM.Sorting.yaml
@@ -1,4 +1,4 @@
-Private: 
+Most Active: 
   type: composition-comparer@1
   comparers:
   - type: score-comparer@1
@@ -86,4 +86,3 @@ Work Dynamic:
   - type: az-comparer@1
     property: Name
     weight: 1
-

--- a/src/RepoM.Api/Resources/RepoM.Sorting.yaml
+++ b/src/RepoM.Api/Resources/RepoM.Sorting.yaml
@@ -1,3 +1,32 @@
+Private: 
+  type: composition-comparer@1
+  comparers:
+  - type: score-comparer@1
+    score-provider:
+      type: is-pinned-scorer@1
+      weight: 40
+  - type: last-opened-comparer@1
+    weight: 30
+  - type: score-comparer@1
+    score-provider:
+      type: usage-scorer@1
+      max-score: 20
+      windows:
+      - until: 00:15:00
+        weight: 4
+        max-items: 10
+      - until: 01:00:00
+        weight: 3
+        max-items: 5
+      - until: 24:00:00
+        weight: 2
+        max-items: 5
+      - until: 168:00:00
+        weight: 1
+        max-items: 10   
+  - type: az-comparer@1
+    property: Name
+    weight: 1
 Work: 
   type: composition-comparer@1
   comparers:
@@ -57,37 +86,4 @@ Work Dynamic:
   - type: az-comparer@1
     property: Name
     weight: 1
-Prive: 
-  type: composition-comparer@1
-  comparers:
-  - type: score-comparer@1
-    score-provider:
-      type: is-pinned-scorer@1
-      weight: 1
-  - type: score-comparer@1
-    score-provider:
-      type: tag-scorer@1
-      weight: 1
-      tag: Prive
-  - type: score-comparer@1
-    score-provider:
-      type: usage-scorer@1
-      max-score: 20
-      windows:
-      - until: 00:15:00
-        weight: 4
-        max-items: 10
-      - until: 01:00:00
-        weight: 3
-        max-items: 5
-      - until: 24:00:00
-        weight: 2
-        max-items: 5
-      - until: 168:00:00
-        weight: 1
-        max-items: 10
-  - type: last-opened-comparer@1
-    weight: 1
-  - type: az-comparer@1
-    property: Name
-    weight: 1
+

--- a/src/RepoM.Api/Resources/RepositoryActionsV2.yaml
+++ b/src/RepoM.Api/Resources/RepositoryActionsV2.yaml
@@ -1,8 +1,12 @@
-context:
+﻿context:
 - type: evaluate-script@1
   content: |-
     func is_null(input)
       ret input == null
+    end
+
+    func is_not_null(input)
+      ret input != null
     end
 
     func get_filename(path)
@@ -47,6 +51,17 @@ context:
       ret repository.branch | string.replace "feature/" "" | string.strip
     end
 
+    func shorten_github_link(github_url)
+      ret github_url | string.replace "https://github.com/" "" | string.replace ".git" "" | string.strip
+    end
+
+    func get_remote_name()
+      if is_null(repository.remotes) || array.size(repository.remotes) == 0
+        ret repository.name
+      end
+      ret shorten_github_link(repository.remotes[0].url) 
+    end
+
     remote_name_origin = get_remote_origin_name();
     is_work_repository = remotes_contain("My-Work");
     is_github_repository = remotes_contain("github.com");
@@ -54,7 +69,17 @@ context:
     solution_files = file.find_files(repository.linux_path, "*.sln");
     solution_file = array.first(solution_files);
     
+    dir_visual_studio = env.ProgramW6432 + "/Microsoft Visual Studio/";
+    dir_windows_terminal_Store = env.LocalAppData + "/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/";
+    dir_windows_terminal_Preview = env.LocalAppData + "/Packages/Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe/";
+    dir_windows_terminal_Unpackaged = env.LocalAppData + "/Packages/Microsoft/WindowsTerminal/";
+
     exe_vs_code = env.LocalAppData + "/Programs/Microsoft VS Code/code.exe";
+    exe_sourcetree = env.LocalAppData + "/SourceTree/SourceTree.exe";
+    exe_gitkraken = env.LocalAppData + "/GitKraken/GitKraken.exe";
+    exe_everything = env.ProgramW6432 + "/Everything/Everything.exe";
+    exe_terminal_commander = env.ProgramW6432 + "/totalcmd/TOTALCMD64.EXE";
+
     
 # Specific var files
 - type: render-variable@1
@@ -91,29 +116,19 @@ context:
 action-menu:
 
 - type: command@1
-  name: Open in Windows File Explorer
+  name: 📂 Open in Windows File Explorer
   command: '"{{ repository.path }}"'
-
-- type: command@1
-  name: Open in Windows Terminal
-  command: wt
-  arguments: -d "{{ repository.linux_path }}"
-
-- type: executable@1
-  name: 'Open in Windows PowerShell'
-  executable: '{{ env.WINDIR }}/System32/WindowsPowerShell/v1.0/powershell.exe'
-  arguments: -executionpolicy bypass -noexit -command "Set-Location '{{ repository.linux_path }}'"
 
 # Open in visual studio when exactly one '.sln' file was found:
 - type: command@1
-  name: Open in Visual Studio
+  name: 🗃️ Open in Visual Studio
   command: '{{ solution_file }}'
-  active: array.size(solution_files) == 1
+  active: array.size(solution_files) == 1 && file.dir_exists(dir_visual_studio)
 
 # Otherwise, Visual studio folder with all '.sln' files when multiple sln files were found:
 - type: folder@1
-  name: Open in Visual Studio
-  active: array.size(solution_files) > 1
+  name: 🗃️ Open in Visual Studio
+  active: array.size(solution_files) > 1 && file.dir_exists(dir_visual_studio)
   actions:
   - type: foreach@1
     enumerable: solution_files
@@ -123,57 +138,114 @@ action-menu:
       name: '{{ get_filename(sln) }}'
       command: '{{ sln }}'
   
-- type: executable@1
-  name: Open in Visual Studio Code
-  executable: '{{ exe_vs_code }}'
-  arguments: '"{{ repository.linux_path }}"'
+- type: command@1
+  name: 📝 Open in Visual Studio Code
+  command: code
+  arguments: '"{{ repository.path }}"'
+  active: file.file_exists(exe_vs_code)
 
 - type: executable@1
   name: Open in Sourcetree
-  executable: '{{ env.LocalAppData }}/SourceTree/SourceTree.exe'
+  executable: '{{ exe_sourcetree }}'
   arguments: -f "{{ repository.windows_path }}"
+  active: file.file_exists(exe_sourcetree)
 
 - type: executable@1
-  name: Open in Everything
-  executable: '{{ env.ProgramW6432 }}/Everything/Everything.exe'
+  name: 📊 Open in GitKraken 🦑
+  executable: '{{ exe_gitkraken }}'
+  arguments: --path "{{ repository.path }}"
+
+- type: command@1
+  name: 🧾 Open in Windows Terminal
+  command: wt
+  arguments: -d "{{ repository.path }}"
+  active: file.dir_exists(dir_windows_terminal_Store) || file.dir_exists(dir_windows_terminal_Preview) || file.dir_exists(dir_windows_terminal_Unpackaged)
+
+- type: executable@1
+  name: 🔍 Open in Everything
+  executable: '{{ exe_everything }}'
   arguments: -s """"{{ repository.path }}""" "
+  active: file.file_exists(exe_everything)
 
 - type: executable@1
   name: Open in TotalCommander
-  executable: '{{ env.ProgramW6432 }}/totalcmd/TOTALCMD64.EXE'
+  executable: '{{ exe_terminal_commander }}'
   arguments: /O /T /L="{{ repository.linux_path }}"
+  active: file.file_exists(exe_terminal_commander)
+
+# - type: executable@1
+#   name: 'Open in Windows PowerShell'
+#   executable: '{{ env.WINDIR }}/System32/WindowsPowerShell/v1.0/powershell.exe'
+#   arguments: -executionpolicy bypass -noexit -command "Set-Location '{{ repository.linux_path }}'"
+
+# - type: executable@1
+#   name: 'Open in Windows Command Prompt'
+#   executable: '{{ env.WINDIR }}/System32/cmd.exe'
+#   arguments: /k cd "{{ repository.linux_path }}"
+
+- type: separator@1
+
+- type: just-text@1
+  name: 'Warning: No GitHub remotes to browse to'
+  active: array.size(repository.remotes) == 0
+
+# single remote, create url menu item
+- type: url@1
+  name: '🔗 GitHub: {{ get_remote_name() }}'
+  url: '{{ repository.remotes[0].url }}'
+  active: array.size(repository.remotes) == 1
+
+# Multiple remotes, create folder with multiple menu items
+- type: folder@1
+  name: 🔗 GitHub remote repositories
+  active: array.size(repository.remotes) > 1
+  actions:
+  - type: foreach@1
+    enumerable: repository.remotes
+    variable: remote
+    actions:
+    - type: url@1
+      name: '[{{ remote.key}}] {{ shorten_github_link(remote.url) }}'
+      url: '{{ remote.url }}'
 
 - type: separator@1
 
 - type: folder@1
-  name: Git
+  name: 📦 Git
   actions:
-  - type: browse-repository@1
+  # - type: browse-repository@1
+  # - type: pin-repository@1
   - type: git-fetch@1
   - type: git-pull@1
   - type: git-push@1
   - type: git-checkout@1
 
 - type: separator@1
-
-- type: ignore-repository@1
-
-- type: separator@1
-  active: is_work_repository
+  # active: is_work_repository
 
 - type: folder@1
-  name: '-- Examples --'
+  name: ❓ About {{get_remote_name()}}
   context:
   - type: render-variable@1
     name: repo_docs_directory
     value: 'C:\docs\{{ repository.name }}\' 
   actions:
   
-  - type: just-text@1
+  - type: clipboard-copy@1
     name: 'Current branch is {{ repository.branch }}'
+    text: '{{ repository.branch }}'
 
-  - type: command@1
-    name: 'Create Directory {{ repo_docs_directory }}'
-    command: cmd
-    arguments: /k mkdir "{{ repo_docs_directory }}"
-    active: '!file.dir_exists(repo_docs_directory)'
+  - type: clipboard-copy@1
+    name: 'Local path is {{ repository.windows_path }}'
+    text: '{{ repository.windows_path }}'
+
+  - type: separator@1
+
+  - type: ignore-repository@1
+    name: ❌ Ignore Repository
+
+  # - type: command@1
+  #   name: 'Create Directory {{ repo_docs_directory }}'
+  #   command: cmd
+  #   arguments: /k mkdir "{{ repo_docs_directory }}"
+  #   active: '!file.dir_exists(repo_docs_directory)'

--- a/src/RepoM.Api/Resources/RepositoryActionsV2.yaml
+++ b/src/RepoM.Api/Resources/RepositoryActionsV2.yaml
@@ -214,7 +214,6 @@ action-menu:
   name: 📦 Git
   actions:
   # - type: browse-repository@1
-  # - type: pin-repository@1
   - type: git-fetch@1
   - type: git-pull@1
   - type: git-push@1
@@ -222,6 +221,8 @@ action-menu:
 
 - type: separator@1
   # active: is_work_repository
+
+- type: pin-repository@1
 
 - type: folder@1
   name: ❓ About {{get_remote_name()}}

--- a/src/RepoM.Api/Resources/TagsV2.yaml
+++ b/src/RepoM.Api/Resources/TagsV2.yaml
@@ -36,11 +36,12 @@ context:
     
 tags:
 
-- tag: work
-  when: is_work_repository
+- tag: github
+  when: 'remotes_contain("github.com")'
 
 - tag: private
   when: '!is_work_repository && repository_path_contains("Projects/Private")'
 
-- tag: github
-  when: 'remotes_contain("github.com")'
+- tag: work
+  when: is_work_repository
+

--- a/src/RepoM.App/RepositoryFiltering/IRepositoryFilteringManager.cs
+++ b/src/RepoM.App/RepositoryFiltering/IRepositoryFilteringManager.cs
@@ -27,5 +27,5 @@ public interface IRepositoryFilteringManager
 
     bool SetQueryParser(string key);
 
-    bool SetFilter(string key);
+    bool SetFilter(string filterName);
 }

--- a/src/RepoM.Plugin.AzureDevOps/AzureDevOpsModule.cs
+++ b/src/RepoM.Plugin.AzureDevOps/AzureDevOpsModule.cs
@@ -7,14 +7,9 @@ using RepoM.Core.Plugin;
 using RepoM.Plugin.AzureDevOps.Internal;
 
 [UsedImplicitly]
-internal class AzureDevOpsModule : IModule
+internal class AzureDevOpsModule(IAzureDevOpsPullRequestService service) : IModule
 {
-    private readonly IAzureDevOpsPullRequestService _service;
-
-    public AzureDevOpsModule(IAzureDevOpsPullRequestService service)
-    {
-        _service = service ?? throw new ArgumentNullException(nameof(service));
-    }
+    private readonly IAzureDevOpsPullRequestService _service = service ?? throw new ArgumentNullException(nameof(service));
 
     public Task StartAsync()
     {

--- a/src/RepoM.Plugin.AzureDevOps/Internal/AzureDevOpsPullRequestService.cs
+++ b/src/RepoM.Plugin.AzureDevOps/Internal/AzureDevOpsPullRequestService.cs
@@ -25,7 +25,7 @@ internal sealed class AzureDevOpsPullRequestService : IAzureDevOpsPullRequestSer
     private readonly ILogger _logger;
     private readonly VssConnection? _connection;
     private GitHttpClient? _azureDevopsGitClient;
-    private readonly List<PullRequest> _emptyList = new(0);
+    private readonly List<PullRequest> _emptyList = [];
 
     private Timer? _updateTimer1;
     private Timer? _updateTimer2;
@@ -36,7 +36,7 @@ internal sealed class AzureDevOpsPullRequestService : IAzureDevOpsPullRequestSer
 
     public AzureDevOpsPullRequestService(IAzureDevopsConfiguration configuration, ILogger logger)
     {
-        _httpClient = new();
+        _httpClient = new HttpClient();
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -53,8 +53,8 @@ internal sealed class AzureDevOpsPullRequestService : IAzureDevOpsPullRequestSer
                     _configuration.AzureDevOpsBaseUrl,
                     new VssBasicCredential(string.Empty, _configuration.AzureDevOpsPersonalAccessToken));
                 _httpClient.BaseAddress = _configuration.AzureDevOpsBaseUrl;
-                _httpClient.DefaultRequestHeaders.Accept.Add(new("application/json"));
-                _httpClient.DefaultRequestHeaders.Authorization = new("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_configuration.AzureDevOpsPersonalAccessToken}")));
+                _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_configuration.AzureDevOpsPersonalAccessToken}")));
             }
 
         }

--- a/src/RepoM.Plugin.AzureDevOps/Internal/PullRequest.cs
+++ b/src/RepoM.Plugin.AzureDevOps/Internal/PullRequest.cs
@@ -2,18 +2,11 @@ namespace RepoM.Plugin.AzureDevOps.Internal;
 
 using System;
 
-internal class PullRequest
+internal class PullRequest(Guid repositoryId, string name, string url)
 {
-    public PullRequest(Guid repositoryId, string name, string url)
-    {
-        RepositoryId = repositoryId;
-        Name = name;
-        Url = url;
-    }
+    public Guid RepositoryId { get; } = repositoryId;
 
-    public Guid RepositoryId { get; }
+    public string Name { get; } = name;
 
-    public string Name { get; }
-
-    public string Url { get; }
+    public string Url { get; } = url;
 }

--- a/src/RepoM.Plugin.AzureDevOps/Internal/WorkItemExtractor.cs
+++ b/src/RepoM.Plugin.AzureDevOps/Internal/WorkItemExtractor.cs
@@ -10,9 +10,9 @@ internal static partial class WorkItemExtractor
 
     public static string[] GetDistinctWorkItemsFromCommitMessages(IEnumerable<string> commitMessages)
     {
-        List<string> results = new();
+        List<string> results = [];
 
-        foreach (string commitMessage in commitMessages)
+        foreach (var commitMessage in commitMessages)
         {
             MatchCollection matches = _workItemRegex.Matches(commitMessage);
             if (matches.Any(m => m.Success))

--- a/src/RepoM.Plugin.Clipboard/ActionMenu/Model/ActionMenus/ClipboardCopy/RepositoryActionClipboardCopyV1.cs
+++ b/src/RepoM.Plugin.Clipboard/ActionMenu/Model/ActionMenus/ClipboardCopy/RepositoryActionClipboardCopyV1.cs
@@ -36,7 +36,7 @@ internal sealed class RepositoryActionClipboardCopyV1 : IMenuAction, IContext
     [Required]
     [Text]
     public Text Text { get; set; } = null!;
-    
+
     /// <inheritdoc cref="IContext.Context"/>
     public Context? Context { get; set; }
 

--- a/src/RepoM.Plugin.Clipboard/RepositoryAction/CopyToClipboardRepositoryCommandExecutor.cs
+++ b/src/RepoM.Plugin.Clipboard/RepositoryAction/CopyToClipboardRepositoryCommandExecutor.cs
@@ -8,14 +8,9 @@ using RepoM.Plugin.Clipboard.RepositoryAction.Actions;
 using TextCopy;
 
 [UsedImplicitly]
-internal class CopyToClipboardRepositoryCommandExecutor : ICommandExecutor<CopyToClipboardRepositoryCommand>
+internal class CopyToClipboardRepositoryCommandExecutor(IClipboard clipboard) : ICommandExecutor<CopyToClipboardRepositoryCommand>
 {
-    private readonly IClipboard _clipboard;
-
-    public CopyToClipboardRepositoryCommandExecutor(IClipboard clipboard)
-    {
-        _clipboard = clipboard ?? throw new ArgumentNullException(nameof(clipboard));
-    }
+    private readonly IClipboard _clipboard = clipboard ?? throw new ArgumentNullException(nameof(clipboard));
 
     public void Execute(IRepository repository, CopyToClipboardRepositoryCommand repositoryCommand)
     {

--- a/src/RepoM.Plugin.Statistics/StatisticsModule.cs
+++ b/src/RepoM.Plugin.Statistics/StatisticsModule.cs
@@ -15,45 +15,34 @@ using RepoM.Core.Plugin.Common;
 using RepoM.Plugin.Statistics.Interface;
 
 [UsedImplicitly]
-internal class StatisticsModule : IModule
+internal class StatisticsModule(
+    IStatisticsService service,
+    IStatisticsConfiguration configuration,
+    IClock clock,
+    IAppDataPathProvider pathProvider,
+    IFileSystem fileSystem,
+    ILogger logger)
+    : IModule
 {
-    private readonly IStatisticsService _service;
-    private readonly IStatisticsConfiguration _configuration;
-    private readonly IClock _clock;
-    private readonly IAppDataPathProvider _pathProvider;
-    private readonly IFileSystem _fileSystem;
-    private readonly ILogger _logger;
+    private readonly IStatisticsService _service = service ?? throw new ArgumentNullException(nameof(service));
+    private readonly IStatisticsConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IClock _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    private readonly IAppDataPathProvider _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+    private readonly IFileSystem _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private string _basePath = string.Empty;
     private IDisposable? _disposable;
-    private readonly JsonSerializerSettings _settings;
-
-    public StatisticsModule(
-        IStatisticsService service,
-        IStatisticsConfiguration configuration,
-        IClock clock,
-        IAppDataPathProvider pathProvider,
-        IFileSystem fileSystem,
-        ILogger logger)
+    private readonly JsonSerializerSettings _settings = new()
     {
-        _service = service ?? throw new ArgumentNullException(nameof(service));
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
-        _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
-        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-        _settings = new JsonSerializerSettings
-            {
-                Formatting = Formatting.None,
-                NullValueHandling = NullValueHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.All,
-            };
-    }
+        Formatting = Formatting.None,
+        NullValueHandling = NullValueHandling.Ignore,
+        TypeNameHandling = TypeNameHandling.All,
+    };
 
     public async Task StartAsync()
     {
         _basePath = _fileSystem.Path.Combine(_pathProvider.AppDataPath, "Module", "Statistics");
-        
+
         _disposable = WriteEventsToFile();
 
         await ProcessEventsFromFile().ConfigureAwait(false);
@@ -151,12 +140,12 @@ internal class StatisticsModule : IModule
                .Buffer(buffer)
                .Subscribe(data =>
                    {
-                       IEvent[] events = [.. data, ];
+                       IEvent[] events = [.. data,];
                        if (events.Length == 0)
                        {
                            return;
                        }
-                    
+
                        var json = JsonConvert.SerializeObject(events, _settings);
                        var filename = _fileSystem.Path.Combine(_basePath, $"statistics.v1.{_clock.Now:yyyy-MM-dd HH.mm.ss}.json");
 

--- a/tests/RepoM.ActionMenu.CodeGen.Tests/RepoM.ActionMenu.CodeGen.Tests.csproj
+++ b/tests/RepoM.ActionMenu.CodeGen.Tests/RepoM.ActionMenu.CodeGen.Tests.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Scriban" Version="5.10.0" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.0" />
     <PackageReference Include="EasyTestFile.XUnit" Version="2.1.5-alpha" />
   </ItemGroup>
 

--- a/tests/RepoM.ActionMenu.Core.TestLib/RepoM.ActionMenu.Core.TestLib.csproj
+++ b/tests/RepoM.ActionMenu.Core.TestLib/RepoM.ActionMenu.Core.TestLib.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Scriban" Version="5.10.0" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RepoM.ActionMenu.Core.Tests/RepoM.ActionMenu.Core.Tests.csproj
+++ b/tests/RepoM.ActionMenu.Core.Tests/RepoM.ActionMenu.Core.Tests.csproj
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Scriban" Version="5.10.0" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RepoM.Plugin.Heidi.Tests/EnvironmentVariableManager.cs
+++ b/tests/RepoM.Plugin.Heidi.Tests/EnvironmentVariableManager.cs
@@ -18,25 +18,16 @@ internal static class EnvironmentVariableManager
         return new ReleaseDisposable(are, key, origValue);
     }
 
-    private sealed class ReleaseDisposable : IDisposable
+    private sealed class ReleaseDisposable(AutoResetEvent are, string key, string? value) : IDisposable
     {
         private readonly object _lock = new();
-        private AutoResetEvent? _are;
-        private readonly string _key;
-        private readonly string? _value;
-
-        public ReleaseDisposable(AutoResetEvent are, string key, string? value)
-        {
-            _are = are;
-            _key = key;
-            _value = value;
-        }
+        private AutoResetEvent? _are = are;
 
         public void Dispose()
         {
             lock (_lock)
             {
-                Environment.SetEnvironmentVariable(_key, _value);
+                Environment.SetEnvironmentVariable(key, value);
                 _are?.Set();
                 _are = null;
             }


### PR DESCRIPTION
This PR does the following:
1. Updates the default Ordering config. It now defaults to Private (renamed to "Most Active" so as to differentiate it from Tags that are similarly named)
2. Changes the default filtering system name to All. The Private filter is changed to only include repos marked as private.
3. Fixes the bug in #145 where the app would default to the first filter found, not to the filter marked as Default.
4. The name "All" is made a reserved filter name.
6. Filters named "Default" will overwrite the "All" setting.
7. `_queryDictionary` was, in fact, a List. No more :)
8. Eliminates redundant `List<T>.Contains()` checks.
9. Fixes the fork display problem ( #170 )
10. Fixes the pin crash ( #169 ) (and possibly #87 ?)
11. Partially fixes the default installation issue ( #156 , and brought up in #151 ). Still think it would be ideal to set them at install or at least at startup so that the app doesn't waste any time whatsoever unnecessarily checking if they're installed every time.
12. Updates Logger and YAML parser
13. Other code simplifications.
14. Improves the overall UI and adds icons

![image](https://github.com/user-attachments/assets/93b4988f-01ba-4512-9da6-c2585540954d)
