### PR TITLE
Improve message when Scriban cannot execute predicate for context menu

### DIFF
--- a/src/RepoM.ActionMenu.Core/Yaml/Model/Templating/ScribanPredicate.cs
+++ b/src/RepoM.ActionMenu.Core/Yaml/Model/Templating/ScribanPredicate.cs
@@ -1,5 +1,6 @@
 namespace RepoM.ActionMenu.Core.Yaml.Model.Templating;
 
+using System;
 using System.Threading.Tasks;
 using RepoM.ActionMenu.Core.Misc;
 using RepoM.ActionMenu.Interface.ActionMenuFactory;
@@ -35,8 +36,15 @@ internal class ScribanPredicate : Predicate, ICreateTemplate
 
         if (instance is TemplateContext tc && _template != null)
         {
-            var result = await _template.EvaluateAsync(tc).ConfigureAwait(false);
-            return ToBool(result);
+            try
+            {
+                var result = await _template.EvaluateAsync(tc).ConfigureAwait(false);
+                return ToBool(result);
+            }
+            catch (Exception e)
+            {
+                throw new PredicateEvaluationException(Value, e);
+            }
         }
 
         return await base.EvaluateAsync(instance).ConfigureAwait(false);

--- a/src/RepoM.ActionMenu.Interface/YamlModel/Templating/Predicate.cs
+++ b/src/RepoM.ActionMenu.Interface/YamlModel/Templating/Predicate.cs
@@ -38,6 +38,7 @@ public class Predicate : EvaluateObjectBase
         return $"{nameof(Predicate)} {base.ToString()} : {DefaultValue}";
     }
 
+    /// <exception cref="PredicateEvaluationException"></exception>
     public virtual async Task<bool> EvaluateAsync(ITemplateEvaluator instance)
     {
         if (StaticValue.HasValue)

--- a/src/RepoM.ActionMenu.Interface/YamlModel/Templating/PredicateEvaluationException.cs
+++ b/src/RepoM.ActionMenu.Interface/YamlModel/Templating/PredicateEvaluationException.cs
@@ -1,0 +1,19 @@
+namespace RepoM.ActionMenu.Interface.YamlModel.Templating;
+
+using System;
+
+public sealed class PredicateEvaluationException : Exception
+{
+    public PredicateEvaluationException(string predicate, Exception innerException)
+        : base(CreateMessage(predicate, innerException), innerException)
+    {
+        PredicateText = predicate;
+    }
+
+    public string PredicateText { get; }
+
+    private static string CreateMessage(string predicateText, Exception exception)
+    {
+        return $"Could not evaluate predicate '{predicateText}' because {exception.Message}";
+    }
+}

--- a/src/RepoM.App/Properties/launchSettings.json
+++ b/src/RepoM.App/Properties/launchSettings.json
@@ -6,6 +6,10 @@
     },
     "RepoM.App": {
       "commandName": "Project"
+    },
+    "RepoM.App appdata": {
+      "commandName": "Project",
+      "commandLineArgs": "--App:AppSettingsPath \"%appdata%\\RepoM\""
     }
   }
 }

--- a/tests/RepoM.ActionMenu.Core.Tests/Yaml/Model/ScribanPredicateTests.cs
+++ b/tests/RepoM.ActionMenu.Core.Tests/Yaml/Model/ScribanPredicateTests.cs
@@ -28,7 +28,10 @@ public class ScribanPredicateTests
         Func<Task<bool>> act = async () => await sut.EvaluateAsync(templateEvaluator);
 
         // assert
-        await act.Should().ThrowAsync<PredicateEvaluationException>().WithMessage("Could not evaluate predicate 'file.exists x' because <input>(1,6) : error : Cannot get the member file.exists for a null object.");
+        (await act.Should().ThrowAsync<PredicateEvaluationException>())
+            .WithMessage("Could not evaluate predicate 'file.exists x' because <input>(1,6) : error : Cannot get the member file.exists for a null object.")
+            .And.PredicateText.Should().Be("file.exists x");
+
     }
 }
 

--- a/tests/RepoM.ActionMenu.Core.Tests/Yaml/Model/ScribanPredicateTests.cs
+++ b/tests/RepoM.ActionMenu.Core.Tests/Yaml/Model/ScribanPredicateTests.cs
@@ -1,0 +1,53 @@
+namespace RepoM.ActionMenu.Core.Tests.Yaml.Model;
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using RepoM.ActionMenu.Core.Misc;
+using RepoM.ActionMenu.Core.Yaml.Model.Templating;
+using RepoM.ActionMenu.Interface.ActionMenuFactory;
+using RepoM.ActionMenu.Interface.YamlModel.Templating;
+using Scriban;
+using Xunit;
+
+public class ScribanPredicateTests
+{
+    [Fact]
+    public async Task EvaluateAsync_ShouldThrowPredicateEvaluationException_WhenPredicateIsWrong()
+    {
+        // arrange
+        var sut = new ScribanPredicate
+            {
+                Value = "file.exists x",
+            };
+        var realTemplateParser = new FixedTemplateParser();
+        ((ICreateTemplate)sut).CreateTemplate(realTemplateParser);
+        ITemplateEvaluator templateEvaluator = new FakeTemplateContext(realTemplateParser);
+
+        // act
+        Func<Task<bool>> act = async () => await sut.EvaluateAsync(templateEvaluator);
+
+        // assert
+        await act.Should().ThrowAsync<PredicateEvaluationException>().WithMessage("Could not evaluate predicate 'file.exists x' because <input>(1,6) : error : Cannot get the member file.exists for a null object.");
+    }
+}
+
+file class FakeTemplateContext : TemplateContext, ITemplateEvaluator
+{
+    private readonly ITemplateParser _templateParser;
+
+    public FakeTemplateContext(ITemplateParser templateParser)
+    {
+        _templateParser = templateParser;
+    }
+    public Task<string> RenderStringAsync(string text)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<object> EvaluateAsync(string text)
+    {
+        Template template = _templateParser.ParseScriptOnly(text);
+        return await template.EvaluateAsync(this).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
Improves feedback when predicate fails


For predicate en `enabled` 
![image](https://github.com/user-attachments/assets/971f4c7a-0735-438b-a1fa-e397c8c9d2a4)

the current version of RepoM shows:

![image](https://github.com/user-attachments/assets/09a163ef-b808-4f59-9eab-337089aa164b)


After this PR, RepoM will show:

![image](https://github.com/user-attachments/assets/416d3fb8-f512-4499-97df-1272455b4f2a)



